### PR TITLE
Pass an argument to the container in order to configure the zap logger

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -21,6 +21,9 @@ spec:
             name: metrics
           command:
           - component-operator
+          args:
+            - --zap-encoder
+            - $(ZAP_ENCODER)
           imagePullPolicy: Always
           env:
             - name: POD_NAME
@@ -29,3 +32,5 @@ spec:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: "component-operator"
+            - name: ZAP_ENCODER
+              value: "console"


### PR DESCRIPTION
- Pass an argument to the operator container in order to configure the zap logger and define an env var to have the possibility to change from `console` to `json`
- Fix for the issue #53 