### PR TITLE
Add role bindings and SecurityContextConstraints as needed by kubedb and tekton

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -4,8 +4,10 @@ import (
 	"flag"
 	"fmt"
 	kubedbv1 "github.com/kubedb/apimachinery/apis/kubedb/v1alpha1"
+	authorizv1 "github.com/openshift/api/authorization/v1"
 	image "github.com/openshift/api/image/v1"
 	route "github.com/openshift/api/route/v1"
+	securityv1 "github.com/openshift/api/security/v1"
 	"github.com/operator-framework/operator-sdk/pkg/log/zap"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
 	"github.com/snowdrop/component-operator/pkg/apis/component/v1alpha2"
@@ -114,6 +116,12 @@ func main() {
 
 func registerAdditionalResources(m manager.Manager) {
 	scheme := m.GetScheme()
+	if err := authorizv1.Install(scheme); err != nil {
+		log.Error(err, "")
+	}
+	if err := securityv1.Install(scheme); err != nil {
+		log.Error(err, "")
+	}
 	if err := kubedbv1.AddToScheme(scheme); err != nil {
 		log.Error(err, "")
 	}

--- a/demo/scripts/end-to-end_fruit_demo.sh
+++ b/demo/scripts/end-to-end_fruit_demo.sh
@@ -48,7 +48,7 @@ function printTitle() {
 }
 
 function waitForAndGetPodName() {
-  local -r counterMax=12
+  local -r counterMax=24
   local -r sleepTime=5
   local counter=0
   local pod=""

--- a/demo/scripts/end-to-end_fruit_demo.sh
+++ b/demo/scripts/end-to-end_fruit_demo.sh
@@ -83,6 +83,16 @@ else
   echo "We DON'T run on OpenShift. So need to change SCC"
 fi
 
+printTitle "Add privileged SCC to the serviceaccount postgres-db and buildbot. Required for the operators Tekton and KubeDB"
+if [ "$isOpenShift" == "true" ]; then
+  echo "We run on Openshift. So we will apply the SCC rule"
+  oc adm policy add-scc-to-user privileged system:serviceaccount:${NS}:postgres-db
+  oc adm policy add-scc-to-user privileged system:serviceaccount:${NS}:build-bot
+  oc adm policy add-role-to-user edit system:serviceaccount:${NS}:build-bot
+else
+  echo "We DON'T run on OpenShift. So need to change SCC"
+fi
+
 printTitle "Deploy the component for the fruit-backend, link and capability"
 kubectl apply -n "${NS}" -f "${DIR}"/../fruit-backend-sb/target/classes/META-INF/dekorate/component.yml
 echo "Sleep ${SLEEP_TIME}"

--- a/demo/scripts/end-to-end_fruit_demo.sh
+++ b/demo/scripts/end-to-end_fruit_demo.sh
@@ -76,16 +76,6 @@ kubectl create ns "${NS}"
 printTitle "Add privileged SCC to the serviceaccount postgres-db and buildbot. Required for the operators Tekton and KubeDB"
 if [ "$isOpenShift" == "true" ]; then
   echo "We run on Openshift. So we will apply the SCC rule"
-  oc adm policy add-scc-to-user privileged system:serviceaccount:"${NS}":postgres-db
-  oc adm policy add-scc-to-user privileged system:serviceaccount:"${NS}":build-bot
-  oc adm policy add-role-to-user edit system:serviceaccount:"${NS}":build-bot
-else
-  echo "We DON'T run on OpenShift. So need to change SCC"
-fi
-
-printTitle "Add privileged SCC to the serviceaccount postgres-db and buildbot. Required for the operators Tekton and KubeDB"
-if [ "$isOpenShift" == "true" ]; then
-  echo "We run on Openshift. So we will apply the SCC rule"
   oc adm policy add-scc-to-user privileged system:serviceaccount:${NS}:postgres-db
   oc adm policy add-scc-to-user privileged system:serviceaccount:${NS}:build-bot
   oc adm policy add-role-to-user edit system:serviceaccount:${NS}:build-bot

--- a/demo/scripts/end-to-end_fruit_demo.sh
+++ b/demo/scripts/end-to-end_fruit_demo.sh
@@ -83,6 +83,15 @@ else
   echo "We DON'T run on OpenShift. So need to change SCC"
 fi
 
+printTitle "Add privileged SCC to the 'build-bot' serviceaccount. Only needed until we sort out SCC issues with Tekton"
+if [ "$isOpenShift" == "true" ]; then
+  echo "We run on Openshift. So we will apply the SCC rule"
+  oc adm policy add-scc-to-user privileged system:serviceaccount:${NS}:build-bot
+else
+  echo "We DON'T run on OpenShift. So need to change SCC"
+fi
+
+
 printTitle "Deploy the component for the fruit-backend, link and capability"
 kubectl apply -n "${NS}" -f "${DIR}"/../fruit-backend-sb/target/classes/META-INF/dekorate/component.yml
 echo "Sleep ${SLEEP_TIME}"

--- a/demo/scripts/end-to-end_fruit_demo.sh
+++ b/demo/scripts/end-to-end_fruit_demo.sh
@@ -83,15 +83,6 @@ else
   echo "We DON'T run on OpenShift. So need to change SCC"
 fi
 
-printTitle "Add privileged SCC to the 'build-bot' serviceaccount. Only needed until we sort out SCC issues with Tekton"
-if [ "$isOpenShift" == "true" ]; then
-  echo "We run on Openshift. So we will apply the SCC rule"
-  oc adm policy add-scc-to-user privileged system:serviceaccount:${NS}:build-bot
-else
-  echo "We DON'T run on OpenShift. So need to change SCC"
-fi
-
-
 printTitle "Deploy the component for the fruit-backend, link and capability"
 kubectl apply -n "${NS}" -f "${DIR}"/../fruit-backend-sb/target/classes/META-INF/dekorate/component.yml
 echo "Sleep ${SLEEP_TIME}"

--- a/deploy/cluster-role.yaml
+++ b/deploy/cluster-role.yaml
@@ -32,6 +32,8 @@ rules:
   - configmaps
   - secrets
   - serviceaccounts
+  - roles
+  - rolebindings
   verbs:
   - "*"
 - apiGroups:

--- a/deploy/cluster-role.yaml
+++ b/deploy/cluster-role.yaml
@@ -32,8 +32,6 @@ rules:
   - configmaps
   - secrets
   - serviceaccounts
-  - roles
-  - rolebindings
   verbs:
   - "*"
 - apiGroups:

--- a/deploy/rbac.yaml
+++ b/deploy/rbac.yaml
@@ -1,5 +1,5 @@
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: component-operator
 rules:
@@ -19,6 +19,8 @@ rules:
   - events
   - configmaps
   - secrets
+  - roles
+  - rolebindings
   verbs:
   - "*"
 - apiGroups:

--- a/deploy/rbac.yaml
+++ b/deploy/rbac.yaml
@@ -19,8 +19,6 @@ rules:
   - events
   - configmaps
   - secrets
-  - roles
-  - rolebindings
   verbs:
   - "*"
 - apiGroups:
@@ -32,6 +30,13 @@ rules:
   - statefulsets
   verbs:
   - "*"
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+    - roles
+    - rolebindings
+  verbs:
+    - "*"
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/examples/demo-v1alpha2/component-build.yml
+++ b/examples/demo-v1alpha2/component-build.yml
@@ -10,9 +10,11 @@ metadata:
 spec:
   deploymentMode: build
   exposeService: true
+  port: 8080
   buildConfig:
-    url: https://github.com/snowdrop/rest-http-example.git
-    ref: 2.1.6-1
-    moduleDirName: .
+    type: "s2i"
+    url: "https://github.com/snowdrop/rest-http-example.git"
+    ref: "2.1.6-1"
+    moduleDirName: "."
   runtime: spring-boot
   version: 2.1.6

--- a/examples/demo-v1alpha2/component-module-backend.yml
+++ b/examples/demo-v1alpha2/component-module-backend.yml
@@ -10,6 +10,7 @@ metadata:
   name: fruit-backend-sb
 spec:
   deploymentMode: build
+  port: 8080
   buildConfig:
     url: https://github.com/snowdrop/component-operator-demo.git
     ref: master

--- a/examples/demo-v1alpha2/component-module-build.yml
+++ b/examples/demo-v1alpha2/component-module-build.yml
@@ -10,6 +10,7 @@ metadata:
   name: fruit-client-sb
 spec:
   deploymentMode: build
+  port: 8080
   buildConfig:
     url: https://github.com/snowdrop/component-operator-demo/
     ref: 0.0.2

--- a/examples/demo-v1alpha2/component.yml
+++ b/examples/demo-v1alpha2/component.yml
@@ -8,6 +8,7 @@ spec:
   deploymentMode: dev
   runtime: spring-boot
   version: 1.5.16
+  port: 8080
   envs:
     - name: SPRING_PROFILES_ACTIVE
       value: openshift-catalog

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/onsi/ginkgo v1.8.0
 	github.com/onsi/gomega v1.5.0
 	github.com/openshift/api v0.0.0-20190322043348-8741ff068a47
-	github.com/operator-framework/operator-sdk v0.7.0
+	github.com/operator-framework/operator-sdk v0.8.1
 	github.com/pkg/errors v0.8.1
 	github.com/rogpeppe/go-internal v1.3.0 // indirect
 	github.com/sirupsen/logrus v1.4.1

--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	k8s.io/client-go v11.0.0+incompatible
 	k8s.io/code-generator v0.0.0-20190419212335-ff26e7842f9d // needed for code generation
 	k8s.io/helm v2.13.1+incompatible // indirect
-	k8s.io/kubernetes v1.14.2 // indirect
+	k8s.io/kubernetes v1.14.2
 	kmodules.xyz/custom-resources v0.0.0-20190508103408-464e8324c3ec // indirect
 	kmodules.xyz/monitoring-agent-api v0.0.0-20190513065523-186af167f817 // indirect
 	kmodules.xyz/objectstore-api v0.0.0-20190516233206-ea3ba546e348 // indirect

--- a/go.sum
+++ b/go.sum
@@ -301,6 +301,8 @@ github.com/openshift/api v0.0.0-20190322043348-8741ff068a47 h1:PAlaAXvwmPxgh8gm0
 github.com/openshift/api v0.0.0-20190322043348-8741ff068a47/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
 github.com/operator-framework/operator-sdk v0.7.0 h1:jRhw5i/x8dn6Uk0VSBg/DohjNNrLdh8WoquoP5Dg50g=
 github.com/operator-framework/operator-sdk v0.7.0/go.mod h1:iVyukRkam5JZa8AnjYf+/G3rk7JI1+M6GsU0sq0B9NA=
+github.com/operator-framework/operator-sdk v0.8.1 h1:TDnWWkYpYuuo53ftRVEsAj0xy7IutkpiUlTsHqNeyiU=
+github.com/operator-framework/operator-sdk v0.8.1/go.mod h1:iVyukRkam5JZa8AnjYf+/G3rk7JI1+M6GsU0sq0B9NA=
 github.com/pborman/uuid v1.2.0 h1:J7Q5mO4ysT1dv8hyrUGHb9+ooztCXu1D8MY8DZYsu3g=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=

--- a/pkg/apis/component/v1alpha2/capability_types.go
+++ b/pkg/apis/component/v1alpha2/capability_types.go
@@ -84,6 +84,15 @@ type Capability struct {
 	Spec    CapabilitySpec   `json:"spec,omitempty"`
 	Status  CapabilityStatus `json:"status,omitempty"`
 	requeue bool
+	changed bool
+}
+
+func (in *Capability) HasChanged() bool {
+	return in.changed
+}
+
+func (in *Capability) SetHasChanged(changed bool) {
+	in.changed = in.changed || changed
 }
 
 func (in *Capability) SetNeedsRequeue(requeue bool) {
@@ -98,6 +107,8 @@ func (in *Capability) SetInitialStatus(msg string) bool {
 	if CapabilityPending != in.Status.Phase || in.Status.Message != msg {
 		in.Status.Phase = CapabilityPending
 		in.Status.Message = msg
+		in.SetHasChanged(true)
+		in.SetNeedsRequeue(true)
 		return true
 	}
 	return false
@@ -112,6 +123,8 @@ func (in *Capability) SetErrorStatus(err error) bool {
 	if CapabilityFailed != in.Status.Phase || errMsg != in.Status.Message {
 		in.Status.Phase = CapabilityFailed
 		in.Status.Message = errMsg
+		in.SetHasChanged(true)
+		in.SetNeedsRequeue(false)
 		return true
 	}
 	return false
@@ -122,6 +135,8 @@ func (in *Capability) SetSuccessStatus(dependentName, msg string) bool {
 		in.Status.Phase = CapabilityReady
 		in.Status.PodName = dependentName
 		in.Status.Message = msg
+		in.SetHasChanged(true)
+		in.requeue = false
 		return true
 	}
 	return false

--- a/pkg/apis/component/v1alpha2/commons.go
+++ b/pkg/apis/component/v1alpha2/commons.go
@@ -35,6 +35,8 @@ type Resource interface {
 	runtime.Object
 	NeedsRequeue() bool
 	SetNeedsRequeue(requeue bool)
+	HasChanged() bool
+	SetHasChanged(changed bool)
 	GetStatusAsString() string
 	ShouldDelete() bool
 	SetErrorStatus(err error) bool

--- a/pkg/apis/component/v1alpha2/component_types.go
+++ b/pkg/apis/component/v1alpha2/component_types.go
@@ -96,6 +96,15 @@ type Component struct {
 	Spec    ComponentSpec   `json:"spec,omitempty"`
 	Status  ComponentStatus `json:"status,omitempty"`
 	requeue bool
+	changed bool
+}
+
+func (in *Component) HasChanged() bool {
+	return in.changed
+}
+
+func (in *Component) SetHasChanged(changed bool) {
+	in.changed = in.changed || changed
 }
 
 func (in *Component) SetNeedsRequeue(requeue bool) {
@@ -121,6 +130,8 @@ func (in *Component) SetInitialStatus(msg string) bool {
 			in.Status.Phase = ComponentBuilding
 		}
 		in.Status.Message = msg
+		in.SetHasChanged(true)
+		in.SetNeedsRequeue(true)
 		return true
 	}
 	return false
@@ -135,6 +146,8 @@ func (in *Component) SetErrorStatus(err error) bool {
 	if ComponentFailed != in.Status.Phase || errMsg != in.Status.Message {
 		in.Status.Phase = ComponentFailed
 		in.Status.Message = errMsg
+		in.SetHasChanged(true)
+		in.SetNeedsRequeue(true)
 		return true
 	}
 	return false
@@ -145,6 +158,8 @@ func (in *Component) SetSuccessStatus(dependentName, msg string) bool {
 		in.Status.Phase = ComponentReady
 		in.Status.PodName = dependentName
 		in.Status.Message = msg
+		in.SetHasChanged(true)
+		in.requeue = false
 		return true
 	}
 	return false

--- a/pkg/apis/component/v1alpha2/link_types.go
+++ b/pkg/apis/component/v1alpha2/link_types.go
@@ -71,6 +71,15 @@ type Link struct {
 	Spec    LinkSpec   `json:"spec,omitempty"`
 	Status  LinkStatus `json:"status,omitempty"`
 	requeue bool
+	changed bool
+}
+
+func (in *Link) HasChanged() bool {
+	return in.changed
+}
+
+func (in *Link) SetHasChanged(changed bool) {
+	in.changed = in.changed || changed
 }
 
 func (in *Link) SetNeedsRequeue(requeue bool) {
@@ -85,6 +94,8 @@ func (in *Link) SetInitialStatus(msg string) bool {
 	if LinkPending != in.Status.Phase || msg != in.Status.Message {
 		in.Status.Phase = LinkPending
 		in.Status.Message = msg
+		in.SetHasChanged(true)
+		in.SetNeedsRequeue(true)
 		return true
 	}
 	return false
@@ -99,6 +110,8 @@ func (in *Link) SetErrorStatus(err error) bool {
 	if LinkFailed != in.Status.Phase || errMsg != in.Status.Message {
 		in.Status.Phase = LinkFailed
 		in.Status.Message = errMsg
+		in.SetHasChanged(true)
+		in.SetNeedsRequeue(true)
 		return true
 	}
 	return false
@@ -108,6 +121,8 @@ func (in *Link) SetSuccessStatus(dependentName, msg string) bool {
 	if LinkReady != in.Status.Phase || msg != in.Status.Message {
 		in.Status.Phase = LinkReady
 		in.Status.Message = msg
+		in.SetHasChanged(true)
+		in.requeue = true
 		return true
 	}
 	return false

--- a/pkg/controller/capability/controller.go
+++ b/pkg/controller/capability/controller.go
@@ -61,7 +61,7 @@ func (r *ReconcileCapability) Delete(object v1alpha2.Resource) (bool, error) {
 	panic("implement me")
 }
 
-func (r *ReconcileCapability) CreateOrUpdate(object v1alpha2.Resource) (wantsRequeue bool, e error) {
+func (r *ReconcileCapability) CreateOrUpdate(object v1alpha2.Resource) (changed bool, e error) {
 	capability := asCapability(object)
 	if strings.ToLower(string(v1alpha2.DatabaseCategory)) == string(capability.Spec.Category) {
 		// Install the 2nd resources and check if the status of the watched resources has changed
@@ -69,7 +69,7 @@ func (r *ReconcileCapability) CreateOrUpdate(object v1alpha2.Resource) (wantsReq
 	} else {
 		e = fmt.Errorf("unsupported '%s' capability category", capability.Spec.Category)
 	}
-	return capability.NeedsRequeue(), e
+	return capability.HasChanged(), e
 }
 
 func (r *ReconcileCapability) isDBReady(p *kubedbv1.Postgres) bool {

--- a/pkg/controller/capability/controller.go
+++ b/pkg/controller/capability/controller.go
@@ -35,10 +35,8 @@ func NewCapabilityReconciler(mgr manager.Manager) *ReconcileCapability {
 
 	r.AddDependentResource(newSecret())
 	r.AddDependentResource(newPostgres())
-	//r.AddDependentResource(controller2.NewRole(r.BaseGenericReconciler))
-	//r.AddDependentResource(controller2.NewRoleBinding(r.BaseGenericReconciler))
-	r.AddDependentResource(controller2.Newk8sRole(r.BaseGenericReconciler))
-	r.AddDependentResource(controller2.Newk8sRoleBinding(r.BaseGenericReconciler))
+	r.AddDependentResource(controller2.NewK8sRole())
+	r.AddDependentResource(controller2.NewK8sRoleBinding())
 	return r
 }
 

--- a/pkg/controller/capability/controller.go
+++ b/pkg/controller/capability/controller.go
@@ -61,7 +61,7 @@ func (r *ReconcileCapability) Delete(object v1alpha2.Resource) (bool, error) {
 	panic("implement me")
 }
 
-func (r *ReconcileCapability) CreateOrUpdate(object v1alpha2.Resource) (changed bool, e error) {
+func (r *ReconcileCapability) CreateOrUpdate(object v1alpha2.Resource) (e error) {
 	capability := asCapability(object)
 	if strings.ToLower(string(v1alpha2.DatabaseCategory)) == string(capability.Spec.Category) {
 		// Install the 2nd resources and check if the status of the watched resources has changed
@@ -69,7 +69,7 @@ func (r *ReconcileCapability) CreateOrUpdate(object v1alpha2.Resource) (changed 
 	} else {
 		e = fmt.Errorf("unsupported '%s' capability category", capability.Spec.Category)
 	}
-	return capability.HasChanged(), e
+	return e
 }
 
 func (r *ReconcileCapability) isDBReady(p *kubedbv1.Postgres) bool {

--- a/pkg/controller/capability/controller.go
+++ b/pkg/controller/capability/controller.go
@@ -35,7 +35,7 @@ func NewCapabilityReconciler(mgr manager.Manager) *ReconcileCapability {
 
 	r.AddDependentResource(newSecret())
 	r.AddDependentResource(newPostgres())
-	r.AddDependentResource(controller2.NewScc(r.BaseGenericReconciler, PostgresName))
+	r.AddDependentResource(controller2.NewScc(r.BaseGenericReconciler, controller2.PostgresName))
 
 	return r
 }

--- a/pkg/controller/capability/controller.go
+++ b/pkg/controller/capability/controller.go
@@ -35,9 +35,10 @@ func NewCapabilityReconciler(mgr manager.Manager) *ReconcileCapability {
 
 	r.AddDependentResource(newSecret())
 	r.AddDependentResource(newPostgres())
-	r.AddDependentResource(controller2.NewRole(r.BaseGenericReconciler))
-	r.AddDependentResource(controller2.NewRoleBinding(r.BaseGenericReconciler))
-
+	//r.AddDependentResource(controller2.NewRole(r.BaseGenericReconciler))
+	//r.AddDependentResource(controller2.NewRoleBinding(r.BaseGenericReconciler))
+	r.AddDependentResource(controller2.Newk8sRole(r.BaseGenericReconciler))
+	r.AddDependentResource(controller2.Newk8sRoleBinding(r.BaseGenericReconciler))
 	return r
 }
 

--- a/pkg/controller/capability/controller.go
+++ b/pkg/controller/capability/controller.go
@@ -35,8 +35,8 @@ func NewCapabilityReconciler(mgr manager.Manager) *ReconcileCapability {
 
 	r.AddDependentResource(newSecret())
 	r.AddDependentResource(newPostgres())
-	r.AddDependentResource(controller2.NewRole())
-	r.AddDependentResource(controller2.NewRoleBinding())
+	r.AddDependentResource(controller2.NewRole(r.BaseGenericReconciler))
+	r.AddDependentResource(controller2.NewRoleBinding(r.BaseGenericReconciler))
 
 	return r
 }

--- a/pkg/controller/capability/controller.go
+++ b/pkg/controller/capability/controller.go
@@ -52,7 +52,7 @@ func (r *ReconcileCapability) IsDependentResourceReady(resource v1alpha2.Resourc
 	if err != nil || !r.isDBReady(db.(*kubedbv1.Postgres)) {
 		return "postgreSQL db", false
 	}
-	return db.GetName(), true
+	return db.(*kubedbv1.Postgres).Name, true
 }
 
 func (r *ReconcileCapability) Delete(object v1alpha2.Resource) (bool, error) {

--- a/pkg/controller/capability/controller.go
+++ b/pkg/controller/capability/controller.go
@@ -35,7 +35,8 @@ func NewCapabilityReconciler(mgr manager.Manager) *ReconcileCapability {
 
 	r.AddDependentResource(newSecret())
 	r.AddDependentResource(newPostgres())
-	r.AddDependentResource(controller2.NewScc(r.BaseGenericReconciler, controller2.PostgresName))
+	r.AddDependentResource(controller2.NewRole())
+	r.AddDependentResource(controller2.NewRoleBinding())
 
 	return r
 }

--- a/pkg/controller/capability/controller.go
+++ b/pkg/controller/capability/controller.go
@@ -35,7 +35,7 @@ func NewCapabilityReconciler(mgr manager.Manager) *ReconcileCapability {
 
 	r.AddDependentResource(newSecret())
 	r.AddDependentResource(newPostgres())
-	r.AddDependentResource(controller2.NewScc(PostgresName))
+	r.AddDependentResource(controller2.NewScc(r.BaseGenericReconciler, PostgresName))
 
 	return r
 }

--- a/pkg/controller/capability/controller.go
+++ b/pkg/controller/capability/controller.go
@@ -35,6 +35,7 @@ func NewCapabilityReconciler(mgr manager.Manager) *ReconcileCapability {
 
 	r.AddDependentResource(newSecret())
 	r.AddDependentResource(newPostgres())
+	r.AddDependentResource(controller2.NewScc(PostgresName))
 
 	return r
 }

--- a/pkg/controller/capability/database.go
+++ b/pkg/controller/capability/database.go
@@ -10,10 +10,8 @@ import (
 )
 
 func (r *ReconcileCapability) installDB(c *v1alpha2.Capability) (e error) {
-	if r.IsTargetClusterRunningOpenShift() {
-		if e = r.CreateIfNeeded(c, &securityv1.SecurityContextConstraints{}); e != nil {
-			return e
-		}
+	if e = r.CreateIfNeeded(c, &securityv1.SecurityContextConstraints{}); e != nil {
+		return e
 	}
 
 	if e = r.CreateIfNeeded(c, &v1.Secret{}); e != nil {

--- a/pkg/controller/capability/database.go
+++ b/pkg/controller/capability/database.go
@@ -3,12 +3,19 @@ package capability
 import (
 	"fmt"
 	kubedbv1 "github.com/kubedb/apimachinery/apis/kubedb/v1alpha1"
+	securityv1 "github.com/openshift/api/security/v1"
 	"github.com/snowdrop/component-operator/pkg/apis/component/v1alpha2"
 	v1 "k8s.io/api/core/v1"
 	"strings"
 )
 
 func (r *ReconcileCapability) installDB(c *v1alpha2.Capability) (e error) {
+	if r.IsTargetClusterRunningOpenShift() {
+		if e = r.CreateIfNeeded(c, &securityv1.SecurityContextConstraints{}); e != nil {
+			return e
+		}
+	}
+
 	if e = r.CreateIfNeeded(c, &v1.Secret{}); e != nil {
 		return e
 	}

--- a/pkg/controller/capability/database.go
+++ b/pkg/controller/capability/database.go
@@ -3,14 +3,17 @@ package capability
 import (
 	"fmt"
 	kubedbv1 "github.com/kubedb/apimachinery/apis/kubedb/v1alpha1"
-	securityv1 "github.com/openshift/api/security/v1"
+	authorizv1 "github.com/openshift/api/authorization/v1"
 	"github.com/snowdrop/component-operator/pkg/apis/component/v1alpha2"
 	v1 "k8s.io/api/core/v1"
 	"strings"
 )
 
 func (r *ReconcileCapability) installDB(c *v1alpha2.Capability) (e error) {
-	if e = r.CreateIfNeeded(c, &securityv1.SecurityContextConstraints{}); e != nil {
+	if e = r.CreateIfNeeded(c, &authorizv1.Role{}); e != nil {
+		return e
+	}
+	if e = r.CreateIfNeeded(c, &authorizv1.RoleBinding{}); e != nil {
 		return e
 	}
 

--- a/pkg/controller/capability/kubedb_postgres.go
+++ b/pkg/controller/capability/kubedb_postgres.go
@@ -5,6 +5,7 @@ import (
 	kubedbv1 "github.com/kubedb/apimachinery/apis/kubedb/v1alpha1"
 	"github.com/snowdrop/component-operator/pkg/apis/component/v1alpha2"
 	"github.com/snowdrop/component-operator/pkg/controller"
+	"github.com/snowdrop/component-operator/pkg/util"
 	apps "k8s.io/api/apps/v1"
 	core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -39,6 +40,14 @@ func (res postgres) ownerAsCapability() *v1alpha2.Capability {
 	return res.Owner().(*v1alpha2.Capability)
 }
 
+func (res postgres) Name() string {
+	return PostgresName(res.Owner())
+}
+
+func PostgresName(owner v1alpha2.Resource) string {
+	return util.DefaultDependentResourceNameFor(owner)
+}
+
 //buildSecret returns the postgres resource
 func (res postgres) Build() (runtime.Object, error) {
 	c := res.ownerAsCapability()
@@ -47,7 +56,7 @@ func (res postgres) Build() (runtime.Object, error) {
 
 	postgres := &kubedbv1.Postgres{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      c.Name,
+			Name:      res.Name(),
 			Namespace: c.Namespace,
 			Labels:    ls,
 		},

--- a/pkg/controller/capability/kubedb_postgres.go
+++ b/pkg/controller/capability/kubedb_postgres.go
@@ -5,7 +5,6 @@ import (
 	kubedbv1 "github.com/kubedb/apimachinery/apis/kubedb/v1alpha1"
 	"github.com/snowdrop/component-operator/pkg/apis/component/v1alpha2"
 	"github.com/snowdrop/component-operator/pkg/controller"
-	"github.com/snowdrop/component-operator/pkg/util"
 	apps "k8s.io/api/apps/v1"
 	core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -41,11 +40,7 @@ func (res postgres) ownerAsCapability() *v1alpha2.Capability {
 }
 
 func (res postgres) Name() string {
-	return PostgresName(res.Owner())
-}
-
-func PostgresName(owner v1alpha2.Resource) string {
-	return util.DefaultDependentResourceNameFor(owner)
+	return controller.PostgresName(res.Owner())
 }
 
 //buildSecret returns the postgres resource

--- a/pkg/controller/capability/kubedb_postgres.go
+++ b/pkg/controller/capability/kubedb_postgres.go
@@ -16,7 +16,7 @@ type postgres struct {
 	*controller.DependentResourceHelper
 }
 
-func (res postgres) Update(toUpdate metav1.Object) (bool, error) {
+func (res postgres) Update(toUpdate runtime.Object) (bool, error) {
 	return false, nil
 }
 

--- a/pkg/controller/capability/secret.go
+++ b/pkg/controller/capability/secret.go
@@ -12,7 +12,7 @@ type secret struct {
 	*controller.DependentResourceHelper
 }
 
-func (res secret) Update(toUpdate metav1.Object) (bool, error) {
+func (res secret) Update(toUpdate runtime.Object) (bool, error) {
 	return false, nil
 }
 

--- a/pkg/controller/component/build_deployment.go
+++ b/pkg/controller/component/build_deployment.go
@@ -2,6 +2,7 @@ package component
 
 import (
 	"github.com/snowdrop/component-operator/pkg/apis/component/v1alpha2"
+	"github.com/snowdrop/component-operator/pkg/controller"
 	"k8s.io/api/apps/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -13,7 +14,7 @@ import (
 //createBuildDeployment returns the Deployment config object to be used for deployment using a container image build by Tekton
 func (res deployment) installBuild() (runtime.Object, error) {
 	c := res.ownerAsComponent()
-	ls := getAppLabels(buildOrDevNamer(c))
+	ls := getAppLabels(controller.DeploymentName(c))
 
 	// create runtime container using built image (= created by the Tekton build task)
 	// r := res.reconciler
@@ -26,7 +27,7 @@ func (res deployment) installBuild() (runtime.Object, error) {
 	// and we will enrich the deployment resource of the runtime container
 	// create a "dev" version of the component to be able to check if the dev deployment exists
 	devDeployment := &appsv1.Deployment{}
-	_, err = res.reconciler.Helper().Fetch(DeploymentNameFor(c, v1alpha2.DevDeploymentMode), c.Namespace, devDeployment)
+	_, err = res.reconciler.Helper().Fetch(controller.DeploymentNameFor(c, v1alpha2.DevDeploymentMode), c.Namespace, devDeployment)
 	if err == nil {
 		devContainer := &devDeployment.Spec.Template.Spec.Containers[0]
 		runtimeContainer.Env = devContainer.Env

--- a/pkg/controller/component/build_deployment.go
+++ b/pkg/controller/component/build_deployment.go
@@ -26,7 +26,7 @@ func (res deployment) installBuild() (runtime.Object, error) {
 	// and we will enrich the deployment resource of the runtime container
 	// create a "dev" version of the component to be able to check if the dev deployment exists
 	devDeployment := &appsv1.Deployment{}
-	_, err = res.reconciler.Helper().Fetch(defaultNamer(c), c.Namespace, devDeployment)
+	_, err = res.reconciler.Helper().Fetch(DeploymentNameFor(c, v1alpha2.DevDeploymentMode), c.Namespace, devDeployment)
 	if err == nil {
 		devContainer := &devDeployment.Spec.Template.Spec.Containers[0]
 		runtimeContainer.Env = devContainer.Env

--- a/pkg/controller/component/controller.go
+++ b/pkg/controller/component/controller.go
@@ -87,7 +87,7 @@ func NewComponentReconciler(mgr manager.Manager) *ReconcileComponent {
 	r.AddDependentResource(newIngress(r))
 	r.AddDependentResource(newTask())
 	r.AddDependentResource(newTaskRun(r))
-	r.AddDependentResource(newScc())
+	r.AddDependentResource(controller2.NewScc(ServiceAccountName))
 	r.AddDependentResource(newRoleBinding())
 
 	return r

--- a/pkg/controller/component/controller.go
+++ b/pkg/controller/component/controller.go
@@ -114,7 +114,7 @@ func (r *ReconcileComponent) IsDependentResourceReady(resource v1alpha2.Resource
 		if err != nil || !r.isBuildSucceed(taskRun.(*taskRunv1alpha1.TaskRun)) {
 			return "taskRun job", false
 		}
-		return taskRun.GetName(), true
+		return taskRun.(*taskRunv1alpha1.TaskRun).Name, true
 	} else {
 		pod, err := r.fetchPod(component)
 		if err != nil || !r.isPodReady(pod) {

--- a/pkg/controller/component/controller.go
+++ b/pkg/controller/component/controller.go
@@ -87,7 +87,7 @@ func NewComponentReconciler(mgr manager.Manager) *ReconcileComponent {
 	r.AddDependentResource(newIngress(r))
 	r.AddDependentResource(newTask())
 	r.AddDependentResource(newTaskRun(r))
-	r.AddDependentResource(controller2.NewScc(r.BaseGenericReconciler, ServiceAccountName))
+	r.AddDependentResource(controller2.NewScc(r.BaseGenericReconciler, controller2.ServiceAccountName))
 	r.AddDependentResource(newRoleBinding())
 
 	return r

--- a/pkg/controller/component/controller.go
+++ b/pkg/controller/component/controller.go
@@ -125,14 +125,14 @@ func (r *ReconcileComponent) IsDependentResourceReady(resource v1alpha2.Resource
 	}
 }
 
-func (r *ReconcileComponent) CreateOrUpdate(object v1alpha2.Resource) (wantsRequeue bool, err error) {
+func (r *ReconcileComponent) CreateOrUpdate(object v1alpha2.Resource) (changed bool, err error) {
 	component := r.asComponent(object)
 	if v1alpha2.BuildDeploymentMode == component.Spec.DeploymentMode {
 		err = r.installBuildMode(component, component.Namespace)
 	} else {
 		err = r.installDevMode(component, component.Namespace)
 	}
-	return component.NeedsRequeue(), err
+	return component.HasChanged(), err
 }
 
 func (r *ReconcileComponent) Delete(resource v1alpha2.Resource) (bool, error) {

--- a/pkg/controller/component/controller.go
+++ b/pkg/controller/component/controller.go
@@ -87,8 +87,8 @@ func NewComponentReconciler(mgr manager.Manager) *ReconcileComponent {
 	r.AddDependentResource(newIngress(r))
 	r.AddDependentResource(newTask())
 	r.AddDependentResource(newTaskRun(r))
-	r.AddDependentResource(controller2.NewRole())
-	r.AddDependentResource(controller2.NewRoleBinding())
+	r.AddDependentResource(controller2.NewRole(r.BaseGenericReconciler))
+	r.AddDependentResource(controller2.NewRoleBinding(r.BaseGenericReconciler))
 
 	return r
 }

--- a/pkg/controller/component/controller.go
+++ b/pkg/controller/component/controller.go
@@ -88,6 +88,7 @@ func NewComponentReconciler(mgr manager.Manager) *ReconcileComponent {
 	r.AddDependentResource(newTask())
 	r.AddDependentResource(newTaskRun(r))
 	r.AddDependentResource(newScc())
+	r.AddDependentResource(newRoleBinding())
 
 	return r
 }

--- a/pkg/controller/component/controller.go
+++ b/pkg/controller/component/controller.go
@@ -102,7 +102,6 @@ type ReconcileComponent struct {
 	*controller2.BaseGenericReconciler
 	runtimeImages map[string]imageInfo
 	supervisor    *v1alpha2.Component
-	onOpenShift   *bool
 }
 
 func (ReconcileComponent) asComponent(object runtime.Object) *v1alpha2.Component {
@@ -137,7 +136,7 @@ func (r *ReconcileComponent) CreateOrUpdate(object v1alpha2.Resource) (wantsRequ
 }
 
 func (r *ReconcileComponent) Delete(resource v1alpha2.Resource) (bool, error) {
-	if r.isTargetClusterRunningOpenShift() {
+	if r.IsTargetClusterRunningOpenShift() {
 		// Delete the ImageStream created by OpenShift if it exists as the Component doesn't own this resource
 		// when it is created during build deployment mode
 		imageStream := &unstructured.Unstructured{

--- a/pkg/controller/component/controller.go
+++ b/pkg/controller/component/controller.go
@@ -87,6 +87,7 @@ func NewComponentReconciler(mgr manager.Manager) *ReconcileComponent {
 	r.AddDependentResource(newIngress(r))
 	r.AddDependentResource(newTask())
 	r.AddDependentResource(newTaskRun(r))
+	r.AddDependentResource(newScc())
 
 	return r
 }

--- a/pkg/controller/component/controller.go
+++ b/pkg/controller/component/controller.go
@@ -87,10 +87,8 @@ func NewComponentReconciler(mgr manager.Manager) *ReconcileComponent {
 	r.AddDependentResource(newIngress(r))
 	r.AddDependentResource(newTask())
 	r.AddDependentResource(newTaskRun(r))
-	// r.AddDependentResource(controller2.NewRole(r.BaseGenericReconciler))
-	// r.AddDependentResource(controller2.NewRoleBinding(r.BaseGenericReconciler))
-	r.AddDependentResource(controller2.Newk8sRole(r.BaseGenericReconciler))
-	r.AddDependentResource(controller2.Newk8sRoleBinding(r.BaseGenericReconciler))
+	r.AddDependentResource(controller2.NewK8sRole())
+	r.AddDependentResource(controller2.NewK8sRoleBinding())
 	return r
 }
 

--- a/pkg/controller/component/controller.go
+++ b/pkg/controller/component/controller.go
@@ -87,9 +87,10 @@ func NewComponentReconciler(mgr manager.Manager) *ReconcileComponent {
 	r.AddDependentResource(newIngress(r))
 	r.AddDependentResource(newTask())
 	r.AddDependentResource(newTaskRun(r))
-	r.AddDependentResource(controller2.NewRole(r.BaseGenericReconciler))
-	r.AddDependentResource(controller2.NewRoleBinding(r.BaseGenericReconciler))
-
+	// r.AddDependentResource(controller2.NewRole(r.BaseGenericReconciler))
+	// r.AddDependentResource(controller2.NewRoleBinding(r.BaseGenericReconciler))
+	r.AddDependentResource(controller2.Newk8sRole(r.BaseGenericReconciler))
+	r.AddDependentResource(controller2.Newk8sRoleBinding(r.BaseGenericReconciler))
 	return r
 }
 

--- a/pkg/controller/component/controller.go
+++ b/pkg/controller/component/controller.go
@@ -125,14 +125,14 @@ func (r *ReconcileComponent) IsDependentResourceReady(resource v1alpha2.Resource
 	}
 }
 
-func (r *ReconcileComponent) CreateOrUpdate(object v1alpha2.Resource) (changed bool, err error) {
+func (r *ReconcileComponent) CreateOrUpdate(object v1alpha2.Resource) (err error) {
 	component := r.asComponent(object)
 	if v1alpha2.BuildDeploymentMode == component.Spec.DeploymentMode {
 		err = r.installBuildMode(component, component.Namespace)
 	} else {
 		err = r.installDevMode(component, component.Namespace)
 	}
-	return component.HasChanged(), err
+	return err
 }
 
 func (r *ReconcileComponent) Delete(resource v1alpha2.Resource) (bool, error) {

--- a/pkg/controller/component/controller.go
+++ b/pkg/controller/component/controller.go
@@ -87,7 +87,7 @@ func NewComponentReconciler(mgr manager.Manager) *ReconcileComponent {
 	r.AddDependentResource(newIngress(r))
 	r.AddDependentResource(newTask())
 	r.AddDependentResource(newTaskRun(r))
-	r.AddDependentResource(controller2.NewScc(ServiceAccountName))
+	r.AddDependentResource(controller2.NewScc(r.BaseGenericReconciler, ServiceAccountName))
 	r.AddDependentResource(newRoleBinding())
 
 	return r

--- a/pkg/controller/component/controller.go
+++ b/pkg/controller/component/controller.go
@@ -87,8 +87,8 @@ func NewComponentReconciler(mgr manager.Manager) *ReconcileComponent {
 	r.AddDependentResource(newIngress(r))
 	r.AddDependentResource(newTask())
 	r.AddDependentResource(newTaskRun(r))
-	r.AddDependentResource(controller2.NewScc(r.BaseGenericReconciler, controller2.ServiceAccountName))
-	r.AddDependentResource(newRoleBinding())
+	r.AddDependentResource(controller2.NewRole())
+	r.AddDependentResource(controller2.NewRoleBinding())
 
 	return r
 }

--- a/pkg/controller/component/dependent.go
+++ b/pkg/controller/component/dependent.go
@@ -3,7 +3,6 @@ package component
 import (
 	"github.com/snowdrop/component-operator/pkg/apis/component/v1alpha2"
 	"github.com/snowdrop/component-operator/pkg/controller"
-	"github.com/snowdrop/component-operator/pkg/util"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -25,16 +24,4 @@ func (res base) ownerAsComponent() *v1alpha2.Component {
 
 func (res base) asComponent(object runtime.Object) *v1alpha2.Component {
 	return object.(*v1alpha2.Component)
-}
-
-func buildOrDevNamer(c *v1alpha2.Component) string {
-	return DeploymentNameFor(c, c.Spec.DeploymentMode)
-}
-
-func DeploymentNameFor(c *v1alpha2.Component, mode v1alpha2.DeploymentMode) string {
-	name := util.DefaultDependentResourceNameFor(c)
-	if v1alpha2.BuildDeploymentMode == mode {
-		return name + "-build"
-	}
-	return name
 }

--- a/pkg/controller/component/dependent.go
+++ b/pkg/controller/component/dependent.go
@@ -3,7 +3,6 @@ package component
 import (
 	"github.com/snowdrop/component-operator/pkg/apis/component/v1alpha2"
 	"github.com/snowdrop/component-operator/pkg/controller"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -11,7 +10,7 @@ type base struct {
 	*controller.DependentResourceHelper
 }
 
-func (res base) Update(toUpdate v1.Object) (bool, error) {
+func (res base) Update(toUpdate runtime.Object) (bool, error) {
 	return false, nil
 }
 

--- a/pkg/controller/component/dependent.go
+++ b/pkg/controller/component/dependent.go
@@ -27,15 +27,14 @@ func (res base) asComponent(object runtime.Object) *v1alpha2.Component {
 	return object.(*v1alpha2.Component)
 }
 
-func buildNamer(component *v1alpha2.Component) string {
-	return util.DefaultDependentResourceNameFor(component) + "-build"
-}
 func buildOrDevNamer(c *v1alpha2.Component) string {
 	return DeploymentNameFor(c, c.Spec.DeploymentMode)
 }
+
 func DeploymentNameFor(c *v1alpha2.Component, mode v1alpha2.DeploymentMode) string {
+	name := util.DefaultDependentResourceNameFor(c)
 	if v1alpha2.BuildDeploymentMode == mode {
-		return buildNamer(c)
+		return name + "-build"
 	}
-	return util.DefaultDependentResourceNameFor(c)
+	return name
 }

--- a/pkg/controller/component/dependent.go
+++ b/pkg/controller/component/dependent.go
@@ -3,6 +3,7 @@ package component
 import (
 	"github.com/snowdrop/component-operator/pkg/apis/component/v1alpha2"
 	"github.com/snowdrop/component-operator/pkg/controller"
+	"github.com/snowdrop/component-operator/pkg/util"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -26,17 +27,15 @@ func (res base) asComponent(object runtime.Object) *v1alpha2.Component {
 	return object.(*v1alpha2.Component)
 }
 
-type namer func(*v1alpha2.Component) string
-
-var defaultNamer namer = func(component *v1alpha2.Component) string {
-	return component.Name
+func buildNamer(component *v1alpha2.Component) string {
+	return util.DefaultDependentResourceNameFor(component) + "-build"
 }
-var buildNamer namer = func(component *v1alpha2.Component) string {
-	return defaultNamer(component) + "-build"
+func buildOrDevNamer(c *v1alpha2.Component) string {
+	return DeploymentNameFor(c, c.Spec.DeploymentMode)
 }
-var buildOrDevNamer = func(c *v1alpha2.Component) string {
-	if v1alpha2.BuildDeploymentMode == c.Spec.DeploymentMode {
+func DeploymentNameFor(c *v1alpha2.Component, mode v1alpha2.DeploymentMode) string {
+	if v1alpha2.BuildDeploymentMode == mode {
 		return buildNamer(c)
 	}
-	return defaultNamer(c)
+	return util.DefaultDependentResourceNameFor(c)
 }

--- a/pkg/controller/component/deployment.go
+++ b/pkg/controller/component/deployment.go
@@ -39,9 +39,5 @@ func (res deployment) Build() (runtime.Object, error) {
 }
 
 func (res deployment) Name() string {
-	c := res.ownerAsComponent()
-	if v1alpha2.BuildDeploymentMode == c.Spec.DeploymentMode {
-		return buildNamer(c)
-	}
-	return defaultNamer(c)
+	return buildOrDevNamer(res.ownerAsComponent())
 }

--- a/pkg/controller/component/deployment.go
+++ b/pkg/controller/component/deployment.go
@@ -39,5 +39,5 @@ func (res deployment) Build() (runtime.Object, error) {
 }
 
 func (res deployment) Name() string {
-	return buildOrDevNamer(res.ownerAsComponent())
+	return controller.DeploymentName(res.ownerAsComponent())
 }

--- a/pkg/controller/component/helpers.go
+++ b/pkg/controller/component/helpers.go
@@ -77,7 +77,7 @@ func (r *ReconcileComponent) PopulateK8sLabels(component *v1alpha2.Component, co
 }
 
 func (r *ReconcileComponent) dockerImageURL(c *v1alpha2.Component) string {
-	if r.isTargetClusterRunningOpenShift() {
+	if r.IsTargetClusterRunningOpenShift() {
 		return "docker-registry.default.svc:5000/" + c.Namespace + "/" + c.Name
 	} else {
 		return "kube-registry.kube-system.svc:5000/" + c.Namespace + "/" + c.Name

--- a/pkg/controller/component/ingress.go
+++ b/pkg/controller/component/ingress.go
@@ -67,5 +67,5 @@ func (res ingress) Build() (runtime.Object, error) {
 }
 
 func (res ingress) ShouldWatch() bool {
-	return !res.reconciler.isTargetClusterRunningOpenShift()
+	return !res.reconciler.IsTargetClusterRunningOpenShift()
 }

--- a/pkg/controller/component/ingress.go
+++ b/pkg/controller/component/ingress.go
@@ -69,3 +69,7 @@ func (res ingress) Build() (runtime.Object, error) {
 func (res ingress) ShouldWatch() bool {
 	return !res.reconciler.IsTargetClusterRunningOpenShift()
 }
+
+func (res ingress) CanBeCreatedOrUpdated() bool {
+	return res.ownerAsComponent().Spec.ExposeService && res.ShouldWatch()
+}

--- a/pkg/controller/component/mode-build.go
+++ b/pkg/controller/component/mode-build.go
@@ -18,7 +18,8 @@ limitations under the License.
 package component
 
 import (
-	authorizv1 "github.com/openshift/api/authorization/v1"
+	// authorizv1 "github.com/openshift/api/authorization/v1"
+	authorizv1 "k8s.io/api/rbac/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	"github.com/snowdrop/component-operator/pkg/apis/component/v1alpha2"
 	pipeline "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"

--- a/pkg/controller/component/mode-build.go
+++ b/pkg/controller/component/mode-build.go
@@ -20,7 +20,6 @@ package component
 import (
 	authorizv1 "github.com/openshift/api/authorization/v1"
 	routev1 "github.com/openshift/api/route/v1"
-	securityv1 "github.com/openshift/api/security/v1"
 	"github.com/snowdrop/component-operator/pkg/apis/component/v1alpha2"
 	pipeline "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	v1 "k8s.io/api/apps/v1"
@@ -34,10 +33,10 @@ func (r *ReconcileComponent) installBuildMode(component *v1alpha2.Component, nam
 		return e
 	}
 
-	if e = r.CreateIfNeeded(component, &authorizv1.RoleBinding{}); e != nil {
+	if e = r.CreateIfNeeded(component, &authorizv1.Role{}); e != nil {
 		return e
 	}
-	if e = r.CreateIfNeeded(component, &securityv1.SecurityContextConstraints{}); e != nil {
+	if e = r.CreateIfNeeded(component, &authorizv1.RoleBinding{}); e != nil {
 		return e
 	}
 

--- a/pkg/controller/component/mode-dev.go
+++ b/pkg/controller/component/mode-dev.go
@@ -19,7 +19,8 @@ package component
 
 import (
 	"fmt"
-	authorizv1 "github.com/openshift/api/authorization/v1"
+	// authorizv1 "github.com/openshift/api/authorization/v1"
+	// authorizv1 "k8s.io/api/rbac/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	"github.com/snowdrop/component-operator/pkg/apis/component/v1alpha2"
 	appsv1 "k8s.io/api/apps/v1"
@@ -39,12 +40,14 @@ func (r *ReconcileComponent) installDevMode(component *v1alpha2.Component, names
 	// Enrich Env Vars with Default values
 	r.populateEnvVar(component)
 
-	if e = r.CreateIfNeeded(component, &authorizv1.Role{}); e != nil {
+    /*	AFAIK THIS IS NIT NEEDED AS WE DON'T BUILD or INSTALL A CAPABILITY
+    if e = r.CreateIfNeeded(component, &authorizv1.Role{}); e != nil {
 		return e
 	}
 	if e = r.CreateIfNeeded(component, &authorizv1.RoleBinding{}); e != nil {
 		return e
-	}
+	}*/
+
 	// Create PVC if it does not exists
 	if e = r.CreateIfNeeded(component, &corev1.PersistentVolumeClaim{}); e != nil {
 		return e

--- a/pkg/controller/component/mode-dev.go
+++ b/pkg/controller/component/mode-dev.go
@@ -19,8 +19,8 @@ package component
 
 import (
 	"fmt"
+	authorizv1 "github.com/openshift/api/authorization/v1"
 	routev1 "github.com/openshift/api/route/v1"
-	securityv1 "github.com/openshift/api/security/v1"
 	"github.com/snowdrop/component-operator/pkg/apis/component/v1alpha2"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -39,10 +39,12 @@ func (r *ReconcileComponent) installDevMode(component *v1alpha2.Component, names
 	// Enrich Env Vars with Default values
 	r.populateEnvVar(component)
 
-	if e = r.CreateIfNeeded(component, &securityv1.SecurityContextConstraints{}); e != nil {
+	if e = r.CreateIfNeeded(component, &authorizv1.Role{}); e != nil {
 		return e
 	}
-
+	if e = r.CreateIfNeeded(component, &authorizv1.RoleBinding{}); e != nil {
+		return e
+	}
 	// Create PVC if it does not exists
 	if e = r.CreateIfNeeded(component, &corev1.PersistentVolumeClaim{}); e != nil {
 		return e

--- a/pkg/controller/component/mode-dev.go
+++ b/pkg/controller/component/mode-dev.go
@@ -52,18 +52,14 @@ func (r *ReconcileComponent) installDevMode(component *v1alpha2.Component, names
 		return e
 	}
 
-	if component.Spec.ExposeService {
-		if r.IsTargetClusterRunningOpenShift() {
-			// Create an OpenShift Route
-			if e = r.CreateIfNeeded(component, &routev1.Route{}); e != nil {
-				return e
-			}
-		} else {
-			// Create an Ingress resource
-			if e = r.CreateIfNeeded(component, &v1beta1.Ingress{}); e != nil {
-				return e
-			}
-		}
+	// Create an OpenShift Route
+	if e = r.CreateIfNeeded(component, &routev1.Route{}); e != nil {
+		return e
+	}
+
+	// Create an Ingress resource
+	if e = r.CreateIfNeeded(component, &v1beta1.Ingress{}); e != nil {
+		return e
 	}
 
 	return

--- a/pkg/controller/component/mode-dev.go
+++ b/pkg/controller/component/mode-dev.go
@@ -20,6 +20,7 @@ package component
 import (
 	"fmt"
 	routev1 "github.com/openshift/api/route/v1"
+	securityv1 "github.com/openshift/api/security/v1"
 	"github.com/snowdrop/component-operator/pkg/apis/component/v1alpha2"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -37,6 +38,10 @@ func (r *ReconcileComponent) installDevMode(component *v1alpha2.Component, names
 
 	// Enrich Env Vars with Default values
 	r.populateEnvVar(component)
+
+	if e = r.CreateIfNeeded(component, &securityv1.SecurityContextConstraints{}); e != nil {
+		return e
+	}
 
 	// Create PVC if it does not exists
 	if e = r.CreateIfNeeded(component, &corev1.PersistentVolumeClaim{}); e != nil {

--- a/pkg/controller/component/pvc.go
+++ b/pkg/controller/component/pvc.go
@@ -56,12 +56,7 @@ func (res pvc) Build() (runtime.Object, error) {
 }
 
 func (res pvc) Name() string {
-	c := res.ownerAsComponent()
-	specified := c.Spec.Storage.Name
-	if len(specified) > 0 {
-		return specified
-	}
-	return "m2-data-" + c.Name
+	return controller.PVCName(res.ownerAsComponent())
 }
 
 func getCapacity(c *v1alpha2.Component) resource.Quantity {

--- a/pkg/controller/component/rolebinding.go
+++ b/pkg/controller/component/rolebinding.go
@@ -2,6 +2,7 @@ package component
 
 import (
 	authorizv1 "github.com/openshift/api/authorization/v1"
+	"github.com/snowdrop/component-operator/pkg/apis/component/v1alpha2"
 	"github.com/snowdrop/component-operator/pkg/controller"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -13,7 +14,7 @@ type rolebinding struct {
 	reconciler *ReconcileComponent // todo: remove
 }
 
-func (res rolebinding) NewInstanceWith(owner metav1.Object) controller.DependentResource {
+func (res rolebinding) NewInstanceWith(owner v1alpha2.Resource) controller.DependentResource {
 	return newOwnedRoleBinding(res.reconciler, owner)
 }
 
@@ -21,8 +22,8 @@ func newRoleBinding(reconciler *ReconcileComponent) rolebinding {
 	return newOwnedRoleBinding(reconciler, nil)
 }
 
-func newOwnedRoleBinding(reconciler *ReconcileComponent, owner metav1.Object) rolebinding {
-	dependent := newBaseDependent(&corev1.Service{}, owner)
+func newOwnedRoleBinding(reconciler *ReconcileComponent, owner v1alpha2.Resource) rolebinding {
+	dependent := newBaseDependent(&authorizv1.RoleBinding{}, owner)
 	rolebinding := rolebinding{
 		base:       dependent,
 		reconciler: reconciler,
@@ -41,7 +42,7 @@ func (res rolebinding) Build() (runtime.Object, error) {
 			Kind:       "RoleBinding",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "edit",
+			Name:      "edit",
 			Namespace: c.Namespace,
 		},
 		RoleRef: corev1.ObjectReference{
@@ -56,8 +57,6 @@ func (res rolebinding) Build() (runtime.Object, error) {
 	}
 	return ser, nil
 }
-
-
 
 // oc get rolebinding/edit -n gytis-test -o yaml
 //apiVersion: authorization.openshift.io/v1

--- a/pkg/controller/component/rolebinding.go
+++ b/pkg/controller/component/rolebinding.go
@@ -39,7 +39,7 @@ func (res rolebinding) Build() (runtime.Object, error) {
 	c := res.ownerAsComponent()
 	ser := &authorizv1.RoleBinding{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "authorization.openshift.io/v1",
+			APIVersion: "rbac.authorization.k8s.io/v1beta1",
 			Kind:       "RoleBinding",
 		},
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controller/component/rolebinding.go
+++ b/pkg/controller/component/rolebinding.go
@@ -1,0 +1,80 @@
+package component
+
+import (
+	authorizv1 "github.com/openshift/api/authorization/v1"
+	"github.com/snowdrop/component-operator/pkg/controller"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+type rolebinding struct {
+	base
+	reconciler *ReconcileComponent // todo: remove
+}
+
+func (res rolebinding) NewInstanceWith(owner metav1.Object) controller.DependentResource {
+	return newOwnedRoleBinding(res.reconciler, owner)
+}
+
+func newRoleBinding(reconciler *ReconcileComponent) rolebinding {
+	return newOwnedRoleBinding(reconciler, nil)
+}
+
+func newOwnedRoleBinding(reconciler *ReconcileComponent, owner metav1.Object) rolebinding {
+	dependent := newBaseDependent(&corev1.Service{}, owner)
+	rolebinding := rolebinding{
+		base:       dependent,
+		reconciler: reconciler,
+	}
+	dependent.SetDelegate(rolebinding)
+	return rolebinding
+}
+
+func (res rolebinding) Build() (runtime.Object, error) {
+	// oc adm policy add-role-to-user edit -z build-bot
+	// TODO: Fetch Edit Role and check if it exists, if not create it. This resource should be deleted if the build/tekton task is deleted (=> could be owned by tekton task maybe ?)
+	c := res.ownerAsComponent()
+	ser := &authorizv1.RoleBinding{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "authorization.openshift.io/v1",
+			Kind:       "RoleBinding",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "edit",
+			Namespace: c.Namespace,
+		},
+		RoleRef: corev1.ObjectReference{
+			Name: "edit",
+		},
+		Subjects: []corev1.ObjectReference{
+			{Kind: "ServiceAccount", Name: "Tekton ServiceAccoiunt -> build-bot", Namespace: c.Namespace},
+		},
+		UserNames: authorizv1.OptionalNames{
+			"system:serviceaccount:<NAMESPACE>:<TEKTON SA -> build-bot>",
+		},
+	}
+	return ser, nil
+}
+
+
+
+// oc get rolebinding/edit -n gytis-test -o yaml
+//apiVersion: authorization.openshift.io/v1
+//groupNames: null
+//kind: RoleBinding
+//metadata:
+//  creationTimestamp: 2019-07-15T10:45:44Z
+//  name: edit
+//  namespace: gytis-test
+//  resourceVersion: "45987567"
+//  selfLink: /apis/authorization.openshift.io/v1/namespaces/gytis-test/rolebindings/edit
+//  uid: b2c34b19-a6ed-11e9-bbd9-107b44b03540
+//roleRef:
+//  name: edit
+//subjects:
+//- kind: ServiceAccount
+//  name: build-bot
+//  namespace: gytis-test
+//userNames:
+//- system:serviceaccount:gytis-test:build-bot

--- a/pkg/controller/component/rolebinding.go
+++ b/pkg/controller/component/rolebinding.go
@@ -12,22 +12,20 @@ import (
 
 type rolebinding struct {
 	base
-	reconciler *ReconcileComponent // todo: remove
 }
 
 func (res rolebinding) NewInstanceWith(owner v1alpha2.Resource) controller.DependentResource {
-	return newOwnedRoleBinding(res.reconciler, owner)
+	return newOwnedRoleBinding(owner)
 }
 
-func newRoleBinding(reconciler *ReconcileComponent) rolebinding {
-	return newOwnedRoleBinding(reconciler, nil)
+func newRoleBinding() rolebinding {
+	return newOwnedRoleBinding(nil)
 }
 
-func newOwnedRoleBinding(reconciler *ReconcileComponent, owner v1alpha2.Resource) rolebinding {
+func newOwnedRoleBinding(owner v1alpha2.Resource) rolebinding {
 	dependent := newBaseDependent(&authorizv1.RoleBinding{}, owner)
 	rolebinding := rolebinding{
-		base:       dependent,
-		reconciler: reconciler,
+		base: dependent,
 	}
 	dependent.SetDelegate(rolebinding)
 	return rolebinding
@@ -38,8 +36,6 @@ func (res rolebinding) Name() string {
 }
 
 func (res rolebinding) Build() (runtime.Object, error) {
-	// oc adm policy add-role-to-user edit -z build-bot
-	// TODO: Fetch Edit Role and check if it exists, if not create it. This resource should be deleted if the build/tekton task is deleted (=> could be owned by tekton task maybe ?)
 	c := res.ownerAsComponent()
 	ser := &authorizv1.RoleBinding{
 		TypeMeta: metav1.TypeMeta{

--- a/pkg/controller/component/rolebinding.go
+++ b/pkg/controller/component/rolebinding.go
@@ -49,7 +49,7 @@ func (res rolebinding) Build() (runtime.Object, error) {
 			Name: "edit",
 		},
 		Subjects: []corev1.ObjectReference{
-			{Kind: "ServiceAccount", Name: "Tekton ServiceAccoiunt -> build-bot", Namespace: c.Namespace},
+			{Kind: "ServiceAccount", Name: "Tekton ServiceAccount -> build-bot", Namespace: c.Namespace},
 		},
 		UserNames: authorizv1.OptionalNames{
 			"system:serviceaccount:<NAMESPACE>:<TEKTON SA -> build-bot>",

--- a/pkg/controller/component/rolebinding.go
+++ b/pkg/controller/component/rolebinding.go
@@ -1,6 +1,7 @@
 package component
 
 import (
+	"fmt"
 	authorizv1 "github.com/openshift/api/authorization/v1"
 	"github.com/snowdrop/component-operator/pkg/apis/component/v1alpha2"
 	"github.com/snowdrop/component-operator/pkg/controller"
@@ -49,31 +50,11 @@ func (res rolebinding) Build() (runtime.Object, error) {
 			Name: "edit",
 		},
 		Subjects: []corev1.ObjectReference{
-			{Kind: "ServiceAccount", Name: "Tekton ServiceAccount -> build-bot", Namespace: c.Namespace},
+			{Kind: "ServiceAccount", Name: serviceAccountName, Namespace: c.Namespace},
 		},
 		UserNames: authorizv1.OptionalNames{
-			"system:serviceaccount:<NAMESPACE>:<TEKTON SA -> build-bot>",
+			fmt.Sprintf("system:serviceaccount:%s:%s", c.Namespace, serviceAccountName),
 		},
 	}
 	return ser, nil
 }
-
-// oc get rolebinding/edit -n gytis-test -o yaml
-//apiVersion: authorization.openshift.io/v1
-//groupNames: null
-//kind: RoleBinding
-//metadata:
-//  creationTimestamp: 2019-07-15T10:45:44Z
-//  name: edit
-//  namespace: gytis-test
-//  resourceVersion: "45987567"
-//  selfLink: /apis/authorization.openshift.io/v1/namespaces/gytis-test/rolebindings/edit
-//  uid: b2c34b19-a6ed-11e9-bbd9-107b44b03540
-//roleRef:
-//  name: edit
-//subjects:
-//- kind: ServiceAccount
-//  name: build-bot
-//  namespace: gytis-test
-//userNames:
-//- system:serviceaccount:gytis-test:build-bot

--- a/pkg/controller/component/rolebinding.go
+++ b/pkg/controller/component/rolebinding.go
@@ -58,3 +58,7 @@ func (res rolebinding) Build() (runtime.Object, error) {
 	}
 	return ser, nil
 }
+
+func (res rolebinding) ShouldWatch() bool {
+	return false
+}

--- a/pkg/controller/component/rolebinding.go
+++ b/pkg/controller/component/rolebinding.go
@@ -50,10 +50,10 @@ func (res rolebinding) Build() (runtime.Object, error) {
 			Name: "edit",
 		},
 		Subjects: []corev1.ObjectReference{
-			{Kind: "ServiceAccount", Name: serviceAccountName, Namespace: c.Namespace},
+			{Kind: "ServiceAccount", Name: ServiceAccountName(c), Namespace: c.Namespace},
 		},
 		UserNames: authorizv1.OptionalNames{
-			fmt.Sprintf("system:serviceaccount:%s:%s", c.Namespace, serviceAccountName),
+			fmt.Sprintf("system:serviceaccount:%s:%s", c.Namespace, ServiceAccountName(c)),
 		},
 	}
 	return ser, nil

--- a/pkg/controller/component/rolebinding.go
+++ b/pkg/controller/component/rolebinding.go
@@ -33,6 +33,10 @@ func newOwnedRoleBinding(reconciler *ReconcileComponent, owner v1alpha2.Resource
 	return rolebinding
 }
 
+func (res rolebinding) Name() string {
+	return "edit"
+}
+
 func (res rolebinding) Build() (runtime.Object, error) {
 	// oc adm policy add-role-to-user edit -z build-bot
 	// TODO: Fetch Edit Role and check if it exists, if not create it. This resource should be deleted if the build/tekton task is deleted (=> could be owned by tekton task maybe ?)
@@ -43,7 +47,7 @@ func (res rolebinding) Build() (runtime.Object, error) {
 			Kind:       "RoleBinding",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "edit",
+			Name:      res.Name(),
 			Namespace: c.Namespace,
 		},
 		RoleRef: corev1.ObjectReference{

--- a/pkg/controller/component/route.go
+++ b/pkg/controller/component/route.go
@@ -52,3 +52,7 @@ func (res route) Build() (runtime.Object, error) {
 func (res route) ShouldWatch() bool {
 	return res.reconciler.IsTargetClusterRunningOpenShift()
 }
+
+func (res route) CanBeCreatedOrUpdated() bool {
+	return res.ownerAsComponent().Spec.ExposeService && res.ShouldWatch()
+}

--- a/pkg/controller/component/route.go
+++ b/pkg/controller/component/route.go
@@ -50,5 +50,5 @@ func (res route) Build() (runtime.Object, error) {
 }
 
 func (res route) ShouldWatch() bool {
-	return res.reconciler.isTargetClusterRunningOpenShift()
+	return res.reconciler.IsTargetClusterRunningOpenShift()
 }

--- a/pkg/controller/component/scc.go
+++ b/pkg/controller/component/scc.go
@@ -5,28 +5,26 @@ import (
 	securityv1 "github.com/openshift/api/security/v1"
 	"github.com/snowdrop/component-operator/pkg/apis/component/v1alpha2"
 	"github.com/snowdrop/component-operator/pkg/controller"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"github.com/snowdrop/component-operator/pkg/util"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
 type scc struct {
 	base
-	reconciler *ReconcileComponent // todo: remove
 }
 
 func (res scc) NewInstanceWith(owner v1alpha2.Resource) controller.DependentResource {
-	return newOwnedScc(res.reconciler, owner)
+	return newOwnedScc(owner)
 }
 
-func newScc(reconciler *ReconcileComponent) scc {
-	return newOwnedScc(reconciler, nil)
+func newScc() scc {
+	return newOwnedScc(nil)
 }
 
-func newOwnedScc(reconciler *ReconcileComponent, owner v1alpha2.Resource) scc {
+func newOwnedScc(owner v1alpha2.Resource) scc {
 	dependent := newBaseDependent(&securityv1.SecurityContextConstraints{}, owner)
 	scc := scc{
-		base:       dependent,
-		reconciler: reconciler,
+		base: dependent,
 	}
 	dependent.SetDelegate(scc)
 	return scc
@@ -37,98 +35,19 @@ func (res scc) Name() string {
 }
 
 func (res scc) Build() (runtime.Object, error) {
-	// oc adm policy add-scc-to-user privileged -z build-bot
-	// TODO: Fetch SCC Privileged and add to the users's list a new sa if it does not exist. This resource is cluster-wide managed and should not be deleted or owned by us
-	ser := &securityv1.SecurityContextConstraints{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "v1",
-			Kind:       "SecurityContextConstraints",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: res.Name(),
-		},
-		Users: []string{
-			fmt.Sprintf("system:serviceaccount:%s:%s", res.Owner().GetNamespace(), serviceAccountName),
-		},
+	panic("scc.Build should never be called: check your code!")
+}
+
+func (res scc) Update(toUpdate runtime.Object) (bool, error) {
+	toUpdateSCC := toUpdate.(*securityv1.SecurityContextConstraints)
+	sccUser := fmt.Sprintf("system:serviceaccount:%s:%s", res.Owner().GetNamespace(), serviceAccountName)
+	if util.Index(toUpdateSCC.Users, sccUser) >= 0 {
+		toUpdateSCC.Users = append(toUpdateSCC.Users, sccUser)
+		return true, nil
 	}
-	return ser, nil
+	return false, nil
 }
 
 func (res scc) ShouldWatch() bool {
 	return false
 }
-
-//  allowHostDirVolumePlugin: true
-//  allowHostIPC: true
-//  allowHostNetwork: true
-//  allowHostPID: true
-//  allowHostPorts: true
-//  allowPrivilegeEscalation: true
-//  allowPrivilegedContainer: true
-//  allowedCapabilities:
-//    - '*'
-//  apiVersion: v1
-//  defaultAddCapabilities: null
-//  fsGroup:
-//    type: RunAsAny
-//  groups:
-//    - system:cluster-admins
-//    - system:nodes
-//    - system:masters
-//  kind: SecurityContextConstraints
-//  metadata:
-//    annotations:
-//      kubernetes.io/description: 'privileged allows access to all privileged and host
-//      features and the ability to run as any user, any group, any fsGroup, and with
-//      any SELinux context.  WARNING: this is the most relaxed SCC and should be used
-//      only for cluster administration. Grant with caution.'
-//    creationTimestamp: "2018-11-26T05:44:02Z"
-//    name: privileged
-//    resourceVersion: "46030068"
-//    selfLink: /api/v1/securitycontextconstraints/privileged
-//    uid: 473da8d3-f13e-11e8-9ad2-107b44b03540
-//  priority: null
-//  readOnlyRootFilesystem: false
-//  requiredDropCapabilities: null
-//  runAsUser:
-//    type: RunAsAny
-//  seLinuxContext:
-//    type: RunAsAny
-//  seccompProfiles:
-//    - '*'
-//  supplementalGroups:
-//    type: RunAsAny
-//  users:
-//    - system:admin
-//    - system:serviceaccount:openshift-infra:build-controller
-//    - system:serviceaccount:openshift-node:sync
-//    - system:serviceaccount:openshift-sdn:sdn
-//    - system:serviceaccount:management-infra:management-admin
-//    - system:serviceaccount:management-infra:inspector-admin
-//    - system:serviceaccount:istio-system:jaeger
-//    - system:serviceaccount:gandrian:default
-//    - system:serviceaccount:istio-system:istio-pilot-service-account
-//    - system:serviceaccount:gandrian:sa-greeting
-//    - system:serviceaccount:openshift-logging:aggregated-logging-fluentd
-//    - system:serviceaccount:cmoullia:default
-//    - system:serviceaccount:cmoullia:build-bot
-//    - system:serviceaccount:demo:build-bot
-//    - system:serviceaccount:demo:my-postgres
-//    - system:serviceaccount:demo:postgres-db
-//    - system:serviceaccount:test1:postgres-db
-//    - system:serviceaccount:claprun:build-bot
-//    - system:serviceaccount:test2:postgres-db
-//    - system:serviceaccount:testclaprun:build-bot
-//    - system:serviceaccount:test1:build-bot
-//    - system:serviceaccount:test2:build-bot
-//    - system:serviceaccount:test:build-bot
-//    - system:serviceaccount:test99:build-bot
-//    - system:serviceaccount:test:postgres-db
-//    - system:serviceaccount:gytis:postgres-db
-//    - system:serviceaccount:gytis:build-bot
-//    - system:serviceaccount:gytis-test:postgres-db
-//    - system:serviceaccount:gytis-test:build-bot
-//    - system:serviceaccount:claprun:postgres-db
-//    - system:serviceaccount:claprun:built-bot
-//  volumes:
-//    - '*'

--- a/pkg/controller/component/scc.go
+++ b/pkg/controller/component/scc.go
@@ -1,0 +1,125 @@
+package component
+
+import (
+	securityv1 "github.com/openshift/api/security/v1"
+	"github.com/snowdrop/component-operator/pkg/controller"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+type scc struct {
+	base
+	reconciler *ReconcileComponent // todo: remove
+}
+
+func (res scc) NewInstanceWith(owner metav1.Object) controller.DependentResource {
+	return newOwnedScc(res.reconciler, owner)
+}
+
+func newScc(reconciler *ReconcileComponent) scc {
+	return newOwnedScc(reconciler, nil)
+}
+
+func newOwnedScc(reconciler *ReconcileComponent, owner metav1.Object) scc {
+	dependent := newBaseDependent(&corev1.Service{}, owner)
+	scc := scc{
+		base:       dependent,
+		reconciler: reconciler,
+	}
+	dependent.SetDelegate(scc)
+	return scc
+}
+
+func (res scc) Build() (runtime.Object, error) {
+	// oc adm policy add-scc-to-user privileged -z build-bot
+	// TODO: Fetch SCC Privileged and add to the users's list a new sa if it does not exist. This resource is cluster-wide managed and should not be deleted or owned by us
+	ser := &securityv1.SecurityContextConstraints{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "SecurityContextConstraints",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "privileged",
+		},
+		Users: []string{
+			"system:serviceaccount:<NAMESPACE>:<Tekton -> SA = build-bot>",
+		},
+	}
+	return ser, nil
+}
+
+//  allowHostDirVolumePlugin: true
+//  allowHostIPC: true
+//  allowHostNetwork: true
+//  allowHostPID: true
+//  allowHostPorts: true
+//  allowPrivilegeEscalation: true
+//  allowPrivilegedContainer: true
+//  allowedCapabilities:
+//    - '*'
+//  apiVersion: v1
+//  defaultAddCapabilities: null
+//  fsGroup:
+//    type: RunAsAny
+//  groups:
+//    - system:cluster-admins
+//    - system:nodes
+//    - system:masters
+//  kind: SecurityContextConstraints
+//  metadata:
+//    annotations:
+//      kubernetes.io/description: 'privileged allows access to all privileged and host
+//      features and the ability to run as any user, any group, any fsGroup, and with
+//      any SELinux context.  WARNING: this is the most relaxed SCC and should be used
+//      only for cluster administration. Grant with caution.'
+//    creationTimestamp: "2018-11-26T05:44:02Z"
+//    name: privileged
+//    resourceVersion: "46030068"
+//    selfLink: /api/v1/securitycontextconstraints/privileged
+//    uid: 473da8d3-f13e-11e8-9ad2-107b44b03540
+//  priority: null
+//  readOnlyRootFilesystem: false
+//  requiredDropCapabilities: null
+//  runAsUser:
+//    type: RunAsAny
+//  seLinuxContext:
+//    type: RunAsAny
+//  seccompProfiles:
+//    - '*'
+//  supplementalGroups:
+//    type: RunAsAny
+//  users:
+//    - system:admin
+//    - system:serviceaccount:openshift-infra:build-controller
+//    - system:serviceaccount:openshift-node:sync
+//    - system:serviceaccount:openshift-sdn:sdn
+//    - system:serviceaccount:management-infra:management-admin
+//    - system:serviceaccount:management-infra:inspector-admin
+//    - system:serviceaccount:istio-system:jaeger
+//    - system:serviceaccount:gandrian:default
+//    - system:serviceaccount:istio-system:istio-pilot-service-account
+//    - system:serviceaccount:gandrian:sa-greeting
+//    - system:serviceaccount:openshift-logging:aggregated-logging-fluentd
+//    - system:serviceaccount:cmoullia:default
+//    - system:serviceaccount:cmoullia:build-bot
+//    - system:serviceaccount:demo:build-bot
+//    - system:serviceaccount:demo:my-postgres
+//    - system:serviceaccount:demo:postgres-db
+//    - system:serviceaccount:test1:postgres-db
+//    - system:serviceaccount:claprun:build-bot
+//    - system:serviceaccount:test2:postgres-db
+//    - system:serviceaccount:testclaprun:build-bot
+//    - system:serviceaccount:test1:build-bot
+//    - system:serviceaccount:test2:build-bot
+//    - system:serviceaccount:test:build-bot
+//    - system:serviceaccount:test99:build-bot
+//    - system:serviceaccount:test:postgres-db
+//    - system:serviceaccount:gytis:postgres-db
+//    - system:serviceaccount:gytis:build-bot
+//    - system:serviceaccount:gytis-test:postgres-db
+//    - system:serviceaccount:gytis-test:build-bot
+//    - system:serviceaccount:claprun:postgres-db
+//    - system:serviceaccount:claprun:built-bot
+//  volumes:
+//    - '*'

--- a/pkg/controller/component/scc.go
+++ b/pkg/controller/component/scc.go
@@ -48,7 +48,7 @@ func (res scc) Build() (runtime.Object, error) {
 			Name: res.Name(),
 		},
 		Users: []string{
-			"system:serviceaccount:<NAMESPACE>:<Tekton -> SA = build-bot>",
+			fmt.Sprintf("system:serviceaccount:%s:%s", res.Owner().GetNamespace(), serviceAccountName),
 		},
 	}
 	return ser, nil

--- a/pkg/controller/component/scc.go
+++ b/pkg/controller/component/scc.go
@@ -1,6 +1,7 @@
 package component
 
 import (
+	"fmt"
 	securityv1 "github.com/openshift/api/security/v1"
 	"github.com/snowdrop/component-operator/pkg/apis/component/v1alpha2"
 	"github.com/snowdrop/component-operator/pkg/controller"
@@ -31,6 +32,10 @@ func newOwnedScc(reconciler *ReconcileComponent, owner v1alpha2.Resource) scc {
 	return scc
 }
 
+func (res scc) Name() string {
+	return "privileged"
+}
+
 func (res scc) Build() (runtime.Object, error) {
 	// oc adm policy add-scc-to-user privileged -z build-bot
 	// TODO: Fetch SCC Privileged and add to the users's list a new sa if it does not exist. This resource is cluster-wide managed and should not be deleted or owned by us
@@ -40,7 +45,7 @@ func (res scc) Build() (runtime.Object, error) {
 			Kind:       "SecurityContextConstraints",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "privileged",
+			Name: res.Name(),
 		},
 		Users: []string{
 			"system:serviceaccount:<NAMESPACE>:<Tekton -> SA = build-bot>",

--- a/pkg/controller/component/scc.go
+++ b/pkg/controller/component/scc.go
@@ -2,8 +2,8 @@ package component
 
 import (
 	securityv1 "github.com/openshift/api/security/v1"
+	"github.com/snowdrop/component-operator/pkg/apis/component/v1alpha2"
 	"github.com/snowdrop/component-operator/pkg/controller"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -13,7 +13,7 @@ type scc struct {
 	reconciler *ReconcileComponent // todo: remove
 }
 
-func (res scc) NewInstanceWith(owner metav1.Object) controller.DependentResource {
+func (res scc) NewInstanceWith(owner v1alpha2.Resource) controller.DependentResource {
 	return newOwnedScc(res.reconciler, owner)
 }
 
@@ -21,8 +21,8 @@ func newScc(reconciler *ReconcileComponent) scc {
 	return newOwnedScc(reconciler, nil)
 }
 
-func newOwnedScc(reconciler *ReconcileComponent, owner metav1.Object) scc {
-	dependent := newBaseDependent(&corev1.Service{}, owner)
+func newOwnedScc(reconciler *ReconcileComponent, owner v1alpha2.Resource) scc {
+	dependent := newBaseDependent(&securityv1.SecurityContextConstraints{}, owner)
 	scc := scc{
 		base:       dependent,
 		reconciler: reconciler,
@@ -47,6 +47,10 @@ func (res scc) Build() (runtime.Object, error) {
 		},
 	}
 	return ser, nil
+}
+
+func (res scc) ShouldWatch() bool {
+	return false
 }
 
 //  allowHostDirVolumePlugin: true

--- a/pkg/controller/component/service.go
+++ b/pkg/controller/component/service.go
@@ -36,7 +36,7 @@ func newOwnedService(reconciler *ReconcileComponent, owner v1alpha2.Resource) se
 
 func (res service) Build() (runtime.Object, error) {
 	c := res.ownerAsComponent()
-	ls := getAppLabels(buildOrDevNamer(c))
+	ls := getAppLabels(controller.DeploymentName(c))
 	ser := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      res.Name(),
@@ -64,7 +64,7 @@ func (res service) Build() (runtime.Object, error) {
 func (res service) Update(toUpdate runtime.Object) (bool, error) {
 	c := res.ownerAsComponent()
 	svc := toUpdate.(*corev1.Service)
-	name := buildOrDevNamer(c)
+	name := controller.DeploymentName(c)
 	if svc.Spec.Selector["app"] != name {
 		svc.Spec.Selector["app"] = name
 		if err := res.reconciler.Client.Update(context.TODO(), svc); err != nil {

--- a/pkg/controller/component/service.go
+++ b/pkg/controller/component/service.go
@@ -61,7 +61,7 @@ func (res service) Build() (runtime.Object, error) {
 	return ser, nil
 }
 
-func (res service) Update(toUpdate metav1.Object) (bool, error) {
+func (res service) Update(toUpdate runtime.Object) (bool, error) {
 	c := res.ownerAsComponent()
 	svc := toUpdate.(*corev1.Service)
 	name := buildOrDevNamer(c)

--- a/pkg/controller/component/serviceaccount.go
+++ b/pkg/controller/component/serviceaccount.go
@@ -43,5 +43,9 @@ func (res serviceAccount) Build() (runtime.Object, error) {
 }
 
 func (res serviceAccount) Name() string {
-	return serviceAccountName
+	return ServiceAccountName(res.Owner())
+}
+
+func ServiceAccountName(owner v1alpha2.Resource) string {
+	return "build-bot"
 }

--- a/pkg/controller/component/serviceaccount.go
+++ b/pkg/controller/component/serviceaccount.go
@@ -43,9 +43,5 @@ func (res serviceAccount) Build() (runtime.Object, error) {
 }
 
 func (res serviceAccount) Name() string {
-	return ServiceAccountName(res.Owner())
-}
-
-func ServiceAccountName(owner v1alpha2.Resource) string {
-	return "build-bot"
+	return controller.ServiceAccountName(res.Owner())
 }

--- a/pkg/controller/component/taskruns.go
+++ b/pkg/controller/component/taskruns.go
@@ -41,7 +41,7 @@ func (res taskRun) Build() (runtime.Object, error) {
 			Labels:    ls,
 		},
 		Spec: v1alpha1.TaskRunSpec{
-			ServiceAccount: serviceAccountName,
+			ServiceAccount: ServiceAccountName(c),
 			TaskRef: &v1alpha1.TaskRef{
 				Name: taskS2iBuildahPushName,
 			},

--- a/pkg/controller/component/taskruns.go
+++ b/pkg/controller/component/taskruns.go
@@ -43,7 +43,7 @@ func (res taskRun) Build() (runtime.Object, error) {
 		Spec: v1alpha1.TaskRunSpec{
 			ServiceAccount: ServiceAccountName(c),
 			TaskRef: &v1alpha1.TaskRef{
-				Name: taskS2iBuildahPushName,
+				Name: TaskName(c),
 			},
 			Inputs: v1alpha1.TaskRunInputs{
 				Params: []v1alpha1.Param{

--- a/pkg/controller/component/taskruns.go
+++ b/pkg/controller/component/taskruns.go
@@ -41,9 +41,9 @@ func (res taskRun) Build() (runtime.Object, error) {
 			Labels:    ls,
 		},
 		Spec: v1alpha1.TaskRunSpec{
-			ServiceAccount: ServiceAccountName(c),
+			ServiceAccount: controller.ServiceAccountName(c),
 			TaskRef: &v1alpha1.TaskRef{
-				Name: TaskName(c),
+				Name: controller.TaskName(c),
 			},
 			Inputs: v1alpha1.TaskRunInputs{
 				Params: []v1alpha1.Param{

--- a/pkg/controller/component/tasks.go
+++ b/pkg/controller/component/tasks.go
@@ -3,6 +3,7 @@ package component
 import (
 	"github.com/snowdrop/component-operator/pkg/apis/component/v1alpha2"
 	"github.com/snowdrop/component-operator/pkg/controller"
+	"github.com/snowdrop/component-operator/pkg/util"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -111,7 +112,7 @@ func (res task) Build() (runtime.Object, error) {
 						},
 					},
 					SecurityContext: &corev1.SecurityContext{
-						Privileged: newTrue(),
+						Privileged: util.NewTrue(),
 					},
 				},
 				// Push the image created to quay.io using as credentials the secret mounted within
@@ -137,7 +138,7 @@ func (res task) Build() (runtime.Object, error) {
 							Name:      "libcontainers"},
 					},
 					SecurityContext: &corev1.SecurityContext{
-						Privileged: newTrue(),
+						Privileged: util.NewTrue(),
 					},
 				},
 			},

--- a/pkg/controller/component/tasks.go
+++ b/pkg/controller/component/tasks.go
@@ -11,7 +11,6 @@ import (
 
 const (
 	taskS2iBuildahPushName = "s2i-buildah-push"
-	serviceAccountName     = "build-bot"
 )
 
 type task struct {

--- a/pkg/controller/component/tasks.go
+++ b/pkg/controller/component/tasks.go
@@ -9,10 +9,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-const (
-	taskS2iBuildahPushName = "s2i-buildah-push"
-)
-
 type task struct {
 	base
 }
@@ -166,5 +162,9 @@ func (res task) Build() (runtime.Object, error) {
 }
 
 func (res task) Name() string {
-	return taskS2iBuildahPushName
+	return TaskName(res.Owner())
+}
+
+func TaskName(owner v1alpha2.Resource) string {
+	return "s2i-buildah-push"
 }

--- a/pkg/controller/component/tasks.go
+++ b/pkg/controller/component/tasks.go
@@ -163,9 +163,5 @@ func (res task) Build() (runtime.Object, error) {
 }
 
 func (res task) Name() string {
-	return TaskName(res.Owner())
-}
-
-func TaskName(owner v1alpha2.Resource) string {
-	return "s2i-buildah-push"
+	return controller.TaskName(res.Owner())
 }

--- a/pkg/controller/dependent.go
+++ b/pkg/controller/dependent.go
@@ -3,7 +3,6 @@ package controller
 import (
 	"context"
 	"github.com/snowdrop/component-operator/pkg/apis/component/v1alpha2"
-	"github.com/snowdrop/component-operator/pkg/util"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -43,7 +42,7 @@ func (res *DependentResourceHelper) SetDelegate(delegate DependentResource) {
 }
 
 func (res DependentResourceHelper) Name() string {
-	return util.DefaultDependentResourceNameFor(res.Owner())
+	return DefaultDependentResourceNameFor(res.Owner())
 }
 
 func (res DependentResourceHelper) Fetch(helper ReconcilerHelper) (runtime.Object, error) {

--- a/pkg/controller/dependent.go
+++ b/pkg/controller/dependent.go
@@ -17,6 +17,7 @@ type DependentResource interface {
 	Owner() v1alpha2.Resource
 	Prototype() runtime.Object
 	ShouldWatch() bool
+	CanBeCreatedOrUpdated() bool
 }
 
 type DependentResourceHelper struct {
@@ -26,6 +27,10 @@ type DependentResourceHelper struct {
 }
 
 func (res DependentResourceHelper) ShouldWatch() bool {
+	return true
+}
+
+func (res DependentResourceHelper) CanBeCreatedOrUpdated() bool {
 	return true
 }
 

--- a/pkg/controller/dependent.go
+++ b/pkg/controller/dependent.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"github.com/snowdrop/component-operator/pkg/apis/component/v1alpha2"
+	"github.com/snowdrop/component-operator/pkg/util"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -37,7 +38,7 @@ func (res *DependentResourceHelper) SetDelegate(delegate DependentResource) {
 }
 
 func (res DependentResourceHelper) Name() string {
-	return res._owner.GetName()
+	return util.DefaultDependentResourceNameFor(res.Owner())
 }
 
 func (res DependentResourceHelper) Fetch(helper ReconcilerHelper) (runtime.Object, error) {

--- a/pkg/controller/dependent.go
+++ b/pkg/controller/dependent.go
@@ -17,6 +17,7 @@ type DependentResource interface {
 	Prototype() runtime.Object
 	ShouldWatch() bool
 	CanBeCreatedOrUpdated() bool
+	ShouldBeOwned() bool
 }
 
 type DependentResourceHelper struct {
@@ -26,6 +27,10 @@ type DependentResourceHelper struct {
 }
 
 func (res DependentResourceHelper) ShouldWatch() bool {
+	return true
+}
+
+func (res DependentResourceHelper) ShouldBeOwned() bool {
 	return true
 }
 

--- a/pkg/controller/dependent.go
+++ b/pkg/controller/dependent.go
@@ -3,16 +3,15 @@ package controller
 import (
 	"context"
 	"github.com/snowdrop/component-operator/pkg/apis/component/v1alpha2"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 )
 
 type DependentResource interface {
 	Name() string
-	Fetch(helper ReconcilerHelper) (v1.Object, error)
+	Fetch(helper ReconcilerHelper) (runtime.Object, error)
 	Build() (runtime.Object, error)
-	Update(toUpdate v1.Object) (bool, error)
+	Update(toUpdate runtime.Object) (bool, error)
 	NewInstanceWith(owner v1alpha2.Resource) DependentResource
 	Owner() v1alpha2.Resource
 	Prototype() runtime.Object
@@ -41,13 +40,13 @@ func (res DependentResourceHelper) Name() string {
 	return res._owner.GetName()
 }
 
-func (res DependentResourceHelper) Fetch(helper ReconcilerHelper) (v1.Object, error) {
+func (res DependentResourceHelper) Fetch(helper ReconcilerHelper) (runtime.Object, error) {
 	delegate := res._delegate
 	into := delegate.Prototype()
 	if err := helper.Client.Get(context.TODO(), types.NamespacedName{Name: delegate.Name(), Namespace: delegate.Owner().GetNamespace()}, into); err != nil {
 		return nil, err
 	}
-	return into.(v1.Object), nil
+	return into, nil
 }
 
 func (res DependentResourceHelper) Owner() v1alpha2.Resource {

--- a/pkg/controller/generic.go
+++ b/pkg/controller/generic.go
@@ -295,8 +295,10 @@ func (b *BaseGenericReconciler) CreateIfNeeded(owner v1alpha2.Resource, resource
 			return errBuildObject
 		}
 		if errors.IsNotFound(err) {
-			if e := controllerutil.SetControllerReference(owner, obj.(v1.Object), b.Scheme); e != nil {
-				b.ReqLogger.Error(err, "Failed to set owner", "owner", owner, "resource", resource.Name())
+			// in most instances, resourceDefinedOwner == owner but some resources might want to return a different one
+			resourceDefinedOwner := resource.Owner()
+			if e := controllerutil.SetControllerReference(resourceDefinedOwner, obj.(v1.Object), b.Scheme); e != nil {
+				b.ReqLogger.Error(err, "Failed to set owner", "owner", resourceDefinedOwner, "resource", resource.Name())
 				return e
 			}
 

--- a/pkg/controller/generic.go
+++ b/pkg/controller/generic.go
@@ -252,7 +252,7 @@ func (b *BaseGenericReconciler) updateStatus(instance v1alpha2.Resource, err err
 
 	// compute the status and update the resource if the status has changed
 	if needsStatusUpdate, needsRequeue := b.ComputeStatus(current, err); needsStatusUpdate {
-		e = b.Client.Status().Update(context.TODO(), current)
+		e = b.Client.Status().Update(context.Background(), current)
 		if e != nil {
 			b.ReqLogger.Error(e, "failed to update status for component "+current.GetName())
 		}

--- a/pkg/controller/generic.go
+++ b/pkg/controller/generic.go
@@ -327,15 +327,19 @@ func (b *BaseGenericReconciler) CreateIfNeeded(owner v1alpha2.Resource, resource
 				}
 			}
 
+			alreadyExists := false
 			if err = b.Client.Create(context.TODO(), obj); err != nil {
 				// ignore error if it's to state that obj already exists
-				if !errors.IsAlreadyExists(err) {
+				alreadyExists = errors.IsAlreadyExists(err)
+				if !alreadyExists {
 					b.ReqLogger.Error(err, "Failed to create new ", "kind", kind)
 					return err
 				}
 			}
-			b.ReqLogger.Info("Created successfully", "kind", kind)
-			owner.SetHasChanged(true)
+			if !alreadyExists {
+				b.ReqLogger.Info("Created successfully", "kind", kind, "name", obj.(v1.Object).GetName())
+				owner.SetHasChanged(true)
+			}
 			return nil
 		}
 		b.ReqLogger.Error(err, "Failed to get", "kind", kind)

--- a/pkg/controller/generic.go
+++ b/pkg/controller/generic.go
@@ -337,8 +337,7 @@ func (b *BaseGenericReconciler) CreateIfNeeded(owner v1alpha2.Resource, resource
 				return e
 			}
 
-			err = b.Client.Create(context.TODO(), obj)
-			if err != nil {
+			if err = b.Client.Create(context.TODO(), obj); err != nil {
 				b.ReqLogger.Error(err, "Failed to create new ", "kind", kind)
 				return err
 			}
@@ -351,6 +350,9 @@ func (b *BaseGenericReconciler) CreateIfNeeded(owner v1alpha2.Resource, resource
 	} else {
 		// if the resource defined an updater, use it to try to update the resource
 		updated, err := resource.Update(res)
+		if err = b.Client.Update(context.TODO(), res); err != nil {
+			b.ReqLogger.Error(err, "Failed to update", "kind", kind)
+		}
 		owner.SetNeedsRequeue(updated)
 		return err
 	}

--- a/pkg/controller/generic.go
+++ b/pkg/controller/generic.go
@@ -45,7 +45,7 @@ type ReconcilerHelper struct {
 
 func (rh ReconcilerHelper) Fetch(name, namespace string, into runtime.Object) (runtime.Object, error) {
 	if err := rh.Client.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: namespace}, into); err != nil {
-		return nil, fmt.Errorf("couldn't fetch '%s' %s from namespace '%s'", name, util.GetObjectName(into), namespace)
+		return nil, fmt.Errorf("couldn't fetch '%s' %s from namespace '%s'", name, GetObjectName(into), namespace)
 	}
 	return into, nil
 }
@@ -122,7 +122,7 @@ func (b *BaseGenericReconciler) factory() ReconcilerFactory {
 }
 
 func (b *BaseGenericReconciler) primaryResourceTypeName() string {
-	return util.GetObjectName(b.primary)
+	return GetObjectName(b.primary)
 }
 
 func (b *BaseGenericReconciler) WatchedSecondaryResourceTypes() []runtime.Object {
@@ -149,7 +149,7 @@ func (b *BaseGenericReconciler) Fetch(into v1alpha2.Resource) (v1alpha2.Resource
 
 func (b *BaseGenericReconciler) MakePending(dependencyName string, resource v1alpha2.Resource) (changed bool, wantsRequeue bool) {
 	msg := fmt.Sprintf("'%s' is not ready for %s '%s' in namespace '%s'",
-		dependencyName, util.GetObjectName(resource), resource.GetName(), resource.GetNamespace())
+		dependencyName, GetObjectName(resource), resource.GetName(), resource.GetNamespace())
 	b.ReqLogger.Info(msg)
 	return resource.SetInitialStatus(msg), true
 }
@@ -165,7 +165,7 @@ func (b *BaseGenericReconciler) Helper() ReconcilerHelper {
 func getKeyFor(resourceType runtime.Object) (key string) {
 	t := reflect.TypeOf(resourceType)
 	pkg := t.PkgPath()
-	kind := util.GetObjectName(resourceType)
+	kind := GetObjectName(resourceType)
 	key = pkg + "/" + kind
 	return
 }
@@ -187,7 +187,7 @@ func (b *BaseGenericReconciler) MustGetDependentResourceFor(owner v1alpha2.Resou
 func (b *BaseGenericReconciler) GetDependentResourceFor(owner v1alpha2.Resource, resourceType runtime.Object) (DependentResource, error) {
 	resource, ok := b.dependents[getKeyFor(resourceType)]
 	if !ok {
-		return nil, fmt.Errorf("couldn't find any dependent resource of kind '%s'", util.GetObjectName(resourceType))
+		return nil, fmt.Errorf("couldn't find any dependent resource of kind '%s'", GetObjectName(resourceType))
 	}
 	return resource.NewInstanceWith(owner), nil
 }
@@ -246,7 +246,7 @@ func (b *BaseGenericReconciler) updateStatus(instance v1alpha2.Resource, err err
 	var e error
 	current, e = b.Fetch(instance)
 	if e != nil {
-		b.ReqLogger.Error(e, fmt.Sprintf("failed to fetch latest version of '%s' %s", instance.GetName(), util.GetObjectName(instance)))
+		b.ReqLogger.Error(e, fmt.Sprintf("failed to fetch latest version of '%s' %s", instance.GetName(), GetObjectName(instance)))
 		return false
 	}
 
@@ -306,7 +306,7 @@ func RegisterNewReconciler(factory GenericReconciler, mgr manager.Manager) error
 }
 
 func controllerNameFor(resource runtime.Object) string {
-	return strings.ToLower(util.GetObjectName(resource)) + "-controller"
+	return strings.ToLower(GetObjectName(resource)) + "-controller"
 }
 
 func (b *BaseGenericReconciler) CreateIfNeeded(owner v1alpha2.Resource, resourceType runtime.Object) error {
@@ -320,7 +320,7 @@ func (b *BaseGenericReconciler) CreateIfNeeded(owner v1alpha2.Resource, resource
 		return nil
 	}
 
-	kind := util.GetObjectName(resourceType)
+	kind := GetObjectName(resourceType)
 	res, err := resource.Fetch(b.Helper())
 	if err != nil {
 		if errors.IsNotFound(err) {

--- a/pkg/controller/generic.go
+++ b/pkg/controller/generic.go
@@ -323,12 +323,13 @@ func (b *BaseGenericReconciler) CreateIfNeeded(owner v1alpha2.Resource, resource
 	kind := util.GetObjectName(resourceType)
 	res, err := resource.Fetch(b.Helper())
 	if err != nil {
-		// create the object
-		obj, errBuildObject := resource.Build()
-		if errBuildObject != nil {
-			return errBuildObject
-		}
 		if errors.IsNotFound(err) {
+			// create the object
+			obj, errBuildObject := resource.Build()
+			if errBuildObject != nil {
+				return errBuildObject
+			}
+
 			// in most instances, resourceDefinedOwner == owner but some resources might want to return a different one
 			resourceDefinedOwner := resource.Owner()
 			if e := controllerutil.SetControllerReference(resourceDefinedOwner, obj.(v1.Object), b.Scheme); e != nil {

--- a/pkg/controller/generic.go
+++ b/pkg/controller/generic.go
@@ -350,8 +350,13 @@ func (b *BaseGenericReconciler) CreateIfNeeded(owner v1alpha2.Resource, resource
 	} else {
 		// if the resource defined an updater, use it to try to update the resource
 		updated, err := resource.Update(res)
-		if err = b.Client.Update(context.TODO(), res); err != nil {
-			b.ReqLogger.Error(err, "Failed to update", "kind", kind)
+		if err != nil {
+			return err
+		}
+		if updated {
+			if err = b.Client.Update(context.TODO(), res); err != nil {
+				b.ReqLogger.Error(err, "Failed to update", "kind", kind)
+			}
 		}
 		owner.SetNeedsRequeue(updated)
 		return err

--- a/pkg/controller/generic.go
+++ b/pkg/controller/generic.go
@@ -315,6 +315,11 @@ func (b *BaseGenericReconciler) CreateIfNeeded(owner v1alpha2.Resource, resource
 		return err
 	}
 
+	// if the resource specifies that it shouldn't be created, exit fast
+	if !resource.CanBeCreatedOrUpdated() {
+		return nil
+	}
+
 	kind := util.GetObjectName(resourceType)
 	res, err := resource.Fetch(b.Helper())
 	if err != nil {

--- a/pkg/controller/generic.go
+++ b/pkg/controller/generic.go
@@ -338,8 +338,11 @@ func (b *BaseGenericReconciler) CreateIfNeeded(owner v1alpha2.Resource, resource
 			}
 
 			if err = b.Client.Create(context.TODO(), obj); err != nil {
-				b.ReqLogger.Error(err, "Failed to create new ", "kind", kind)
-				return err
+				// ignore error if it's to state that obj already exists
+				if !errors.IsAlreadyExists(err) {
+					b.ReqLogger.Error(err, "Failed to create new ", "kind", kind)
+					return err
+				}
 			}
 			b.ReqLogger.Info("Created successfully", "kind", kind)
 			owner.SetNeedsRequeue(true)

--- a/pkg/controller/k8srole.go
+++ b/pkg/controller/k8srole.go
@@ -9,7 +9,6 @@ import (
 
 type k8srole struct {
 	*DependentResourceHelper
-	reconciler *BaseGenericReconciler
 }
 
 func (res k8srole) Update(toUpdate runtime.Object) (bool, error) {
@@ -17,14 +16,14 @@ func (res k8srole) Update(toUpdate runtime.Object) (bool, error) {
 }
 
 func (res k8srole) NewInstanceWith(owner v1alpha2.Resource) DependentResource {
-	return newOwnedk8sRole(res.reconciler, owner)
+	return newOwnedK8sRole(owner)
 }
 
-func Newk8sRole(reconciler *BaseGenericReconciler) k8srole {
-	return newOwnedk8sRole(reconciler, nil)
+func NewK8sRole() k8srole {
+	return newOwnedK8sRole(nil)
 }
 
-func newOwnedk8sRole(reconciler *BaseGenericReconciler, owner v1alpha2.Resource) k8srole {
+func newOwnedK8sRole(owner v1alpha2.Resource) k8srole {
 	dependent := NewDependentResource(&authorizv1.Role{}, owner)
 	role := k8srole{DependentResourceHelper: dependent}
 	dependent.SetDelegate(role)

--- a/pkg/controller/k8srole.go
+++ b/pkg/controller/k8srole.go
@@ -9,6 +9,7 @@ import (
 
 type k8srole struct {
 	*DependentResourceHelper
+	reconciler *BaseGenericReconciler
 }
 
 func (res k8srole) Update(toUpdate runtime.Object) (bool, error) {
@@ -16,14 +17,14 @@ func (res k8srole) Update(toUpdate runtime.Object) (bool, error) {
 }
 
 func (res k8srole) NewInstanceWith(owner v1alpha2.Resource) DependentResource {
-	return newOwnedk8srole(owner)
+	return newOwnedk8sRole(res.reconciler, owner)
 }
 
-func Newk8sRole() k8srole {
-	return newOwnedk8srole(nil)
+func Newk8sRole(reconciler *BaseGenericReconciler) k8srole {
+	return newOwnedk8sRole(reconciler, nil)
 }
 
-func newOwnedk8srole(owner v1alpha2.Resource) k8srole {
+func newOwnedk8sRole(reconciler *BaseGenericReconciler, owner v1alpha2.Resource) k8srole {
 	dependent := NewDependentResource(&authorizv1.Role{}, owner)
 	role := k8srole{DependentResourceHelper: dependent}
 	dependent.SetDelegate(role)

--- a/pkg/controller/k8srole.go
+++ b/pkg/controller/k8srole.go
@@ -1,0 +1,58 @@
+package controller
+
+import (
+	"github.com/snowdrop/component-operator/pkg/apis/component/v1alpha2"
+	authorizv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+type k8srole struct {
+	*DependentResourceHelper
+}
+
+func (res k8srole) Update(toUpdate runtime.Object) (bool, error) {
+	return false, nil
+}
+
+func (res k8srole) NewInstanceWith(owner v1alpha2.Resource) DependentResource {
+	return newOwnedk8srole(owner)
+}
+
+func Newk8sRole() k8srole {
+	return newOwnedk8srole(nil)
+}
+
+func newOwnedk8srole(owner v1alpha2.Resource) k8srole {
+	dependent := NewDependentResource(&authorizv1.Role{}, owner)
+	role := k8srole{DependentResourceHelper: dependent}
+	dependent.SetDelegate(role)
+	return role
+}
+
+func (res k8srole) Name() string {
+	return RoleName(res.Owner())
+}
+
+func (res k8srole) Build() (runtime.Object, error) {
+	c := res.Owner()
+	ser := &authorizv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      res.Name(),
+			Namespace: c.GetNamespace(),
+		},
+		Rules: []authorizv1.PolicyRule{
+			{
+				APIGroups:     []string{"security.openshift.io"},
+				Resources:     []string{"securitycontextconstraints"},
+				ResourceNames: []string{"privileged"},
+				Verbs:         []string{"use"},
+			},
+		},
+	}
+	return ser, nil
+}
+
+func (res k8srole) ShouldWatch() bool {
+	return false
+}

--- a/pkg/controller/k8srolebinding.go
+++ b/pkg/controller/k8srolebinding.go
@@ -9,7 +9,6 @@ import (
 
 type k8srolebinding struct {
 	*DependentResourceHelper
-	reconciler *BaseGenericReconciler
 }
 
 func (res k8srolebinding) Update(toUpdate runtime.Object) (bool, error) {
@@ -17,14 +16,14 @@ func (res k8srolebinding) Update(toUpdate runtime.Object) (bool, error) {
 }
 
 func (res k8srolebinding) NewInstanceWith(owner v1alpha2.Resource) DependentResource {
-	return newOwnedk8sRoleBinding(res.reconciler, owner)
+	return newOwnedK8sRoleBinding(owner)
 }
 
-func Newk8sRoleBinding(reconciler *BaseGenericReconciler) k8srolebinding {
-	return newOwnedk8sRoleBinding(reconciler, nil)
+func NewK8sRoleBinding() k8srolebinding {
+	return newOwnedK8sRoleBinding(nil)
 }
 
-func newOwnedk8sRoleBinding(reconciler *BaseGenericReconciler, owner v1alpha2.Resource) k8srolebinding {
+func newOwnedK8sRoleBinding(owner v1alpha2.Resource) k8srolebinding {
 	dependent := NewDependentResource(&authorizv1.RoleBinding{}, owner)
 	rolebinding := k8srolebinding{
 		DependentResourceHelper: dependent,

--- a/pkg/controller/k8srolebinding.go
+++ b/pkg/controller/k8srolebinding.go
@@ -9,6 +9,7 @@ import (
 
 type k8srolebinding struct {
 	*DependentResourceHelper
+	reconciler *BaseGenericReconciler
 }
 
 func (res k8srolebinding) Update(toUpdate runtime.Object) (bool, error) {
@@ -16,14 +17,14 @@ func (res k8srolebinding) Update(toUpdate runtime.Object) (bool, error) {
 }
 
 func (res k8srolebinding) NewInstanceWith(owner v1alpha2.Resource) DependentResource {
-	return newOwnedk8sRoleBinding(owner)
+	return newOwnedk8sRoleBinding(res.reconciler, owner)
 }
 
-func Newk8sRoleBinding() k8srolebinding {
-	return newOwnedk8sRoleBinding(nil)
+func Newk8sRoleBinding(reconciler *BaseGenericReconciler) k8srolebinding {
+	return newOwnedk8sRoleBinding(reconciler, nil)
 }
 
-func newOwnedk8sRoleBinding(owner v1alpha2.Resource) k8srolebinding {
+func newOwnedk8sRoleBinding(reconciler *BaseGenericReconciler, owner v1alpha2.Resource) k8srolebinding {
 	dependent := NewDependentResource(&authorizv1.RoleBinding{}, owner)
 	rolebinding := k8srolebinding{
 		DependentResourceHelper: dependent,

--- a/pkg/controller/k8srolebinding.go
+++ b/pkg/controller/k8srolebinding.go
@@ -1,0 +1,60 @@
+package controller
+
+import (
+	authorizv1 "k8s.io/api/rbac/v1"
+	"github.com/snowdrop/component-operator/pkg/apis/component/v1alpha2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+type k8srolebinding struct {
+	*DependentResourceHelper
+}
+
+func (res k8srolebinding) Update(toUpdate runtime.Object) (bool, error) {
+	return false, nil
+}
+
+func (res k8srolebinding) NewInstanceWith(owner v1alpha2.Resource) DependentResource {
+	return newOwnedk8sRoleBinding(owner)
+}
+
+func Newk8sRoleBinding() k8srolebinding {
+	return newOwnedk8sRoleBinding(nil)
+}
+
+func newOwnedk8sRoleBinding(owner v1alpha2.Resource) k8srolebinding {
+	dependent := NewDependentResource(&authorizv1.RoleBinding{}, owner)
+	rolebinding := k8srolebinding{
+		DependentResourceHelper: dependent,
+	}
+	dependent.SetDelegate(rolebinding)
+	return rolebinding
+}
+
+func (res k8srolebinding) Name() string {
+	return "use-scc-privileged"
+}
+
+func (res k8srolebinding) Build() (runtime.Object, error) {
+	c := res.Owner()
+	namespace := c.GetNamespace()
+	ser := &authorizv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      res.Name(),
+			Namespace: namespace,
+		},
+		RoleRef: authorizv1.RoleRef{
+			Kind:       "Role",
+			Name:       RoleName(c),
+		},
+		Subjects: []authorizv1.Subject{
+			{Kind: "ServiceAccount", Name: ServiceAccountName(c), Namespace: namespace},
+		},
+	}
+	return ser, nil
+}
+
+func (res k8srolebinding) ShouldWatch() bool {
+	return false
+}

--- a/pkg/controller/names.go
+++ b/pkg/controller/names.go
@@ -1,0 +1,59 @@
+package controller
+
+import (
+	"fmt"
+	"github.com/snowdrop/component-operator/pkg/apis/component/v1alpha2"
+	"k8s.io/apimachinery/pkg/runtime"
+	"reflect"
+)
+
+func PostgresName(owner v1alpha2.Resource) string {
+	return DefaultDependentResourceNameFor(owner)
+}
+
+func DeploymentName(c *v1alpha2.Component) string {
+	return DeploymentNameFor(c, c.Spec.DeploymentMode)
+}
+
+func DeploymentNameFor(c *v1alpha2.Component, mode v1alpha2.DeploymentMode) string {
+	name := DefaultDependentResourceNameFor(c)
+	if v1alpha2.BuildDeploymentMode == mode {
+		return name + "-build"
+	}
+	return name
+}
+
+func PVCName(c *v1alpha2.Component) string {
+	specified := c.Spec.Storage.Name
+	if len(specified) > 0 {
+		return specified
+	}
+	return "m2-data-" + c.Name // todo: use better default name?
+}
+
+func DefaultDependentResourceNameFor(owner v1alpha2.Resource) string {
+	return owner.GetName()
+}
+
+func ServiceAccountName(owner v1alpha2.Resource) string {
+	switch owner.(type) {
+	case *v1alpha2.Capability:
+		return PostgresName(owner) // todo: fix me
+	case *v1alpha2.Component:
+		return "build-bot"
+	default:
+		panic(fmt.Sprintf("a service account shouldn't be created for '%s' %s owner", owner.GetName(), GetObjectName(owner)))
+	}
+}
+
+func GetObjectName(object runtime.Object) string {
+	t := reflect.TypeOf(object)
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	return t.Name()
+}
+
+func TaskName(owner v1alpha2.Resource) string {
+	return "s2i-buildah-push"
+}

--- a/pkg/controller/role.go
+++ b/pkg/controller/role.go
@@ -1,0 +1,62 @@
+package controller
+
+import (
+	authorizv1 "github.com/openshift/api/authorization/v1"
+	"github.com/snowdrop/component-operator/pkg/apis/component/v1alpha2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+type role struct {
+	*DependentResourceHelper
+}
+
+func (res role) Update(toUpdate runtime.Object) (bool, error) {
+	return false, nil
+}
+
+func (res role) NewInstanceWith(owner v1alpha2.Resource) DependentResource {
+	return newOwnedRole(owner)
+}
+
+func NewRole() role {
+	return newOwnedRole(nil)
+}
+
+func newOwnedRole(owner v1alpha2.Resource) role {
+	dependent := NewDependentResource(&authorizv1.Role{}, owner)
+	role := role{DependentResourceHelper: dependent}
+	dependent.SetDelegate(role)
+	return role
+}
+
+func RoleName(owner v1alpha2.Resource) string {
+	return "use-scc-privileged-role"
+}
+
+func (res role) Name() string {
+	return RoleName(res.Owner())
+}
+
+func (res role) Build() (runtime.Object, error) {
+	c := res.Owner()
+	ser := &authorizv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      res.Name(),
+			Namespace: c.GetNamespace(),
+		},
+		Rules: []authorizv1.PolicyRule{
+			{
+				APIGroups:     []string{"security.openshift.io"},
+				Resources:     []string{"securitycontextconstraints"},
+				ResourceNames: []string{"privileged"},
+				Verbs:         []string{"use"},
+			},
+		},
+	}
+	return ser, nil
+}
+
+func (res role) ShouldWatch() bool {
+	return false
+}

--- a/pkg/controller/role.go
+++ b/pkg/controller/role.go
@@ -60,3 +60,7 @@ func (res role) Build() (runtime.Object, error) {
 func (res role) ShouldWatch() bool {
 	return false
 }
+
+func (res role) ShouldBeOwned() bool {
+	return false
+}

--- a/pkg/controller/rolebinding.go
+++ b/pkg/controller/rolebinding.go
@@ -74,8 +74,11 @@ func (res rolebinding) Build() (runtime.Object, error) {
 			APIVersion: "rbac.authorization.k8s.io/v1beta1",
 			Namespace:  namespace,
 		},
+		// todo: the second service account should be added on demand in Update but for some reason the server doesn't accept it
+		//  despite returning 200OK on the operation… :/
 		Subjects: []corev1.ObjectReference{
 			{Kind: "ServiceAccount", Name: ServiceAccountName(c), Namespace: namespace},
+			{Kind: "ServiceAccount", Name: PostgresName(c), Namespace: namespace},
 		},
 	}
 	return ser, nil

--- a/pkg/controller/rolebinding.go
+++ b/pkg/controller/rolebinding.go
@@ -72,6 +72,7 @@ func (res rolebinding) Build() (runtime.Object, error) {
 			Kind:       "Role",
 			Name:       RoleName(c),
 			APIVersion: "rbac.authorization.k8s.io/v1beta1",
+			Namespace:  namespace,
 		},
 		Subjects: []corev1.ObjectReference{
 			{Kind: "ServiceAccount", Name: ServiceAccountName(c), Namespace: namespace},

--- a/pkg/controller/rolebinding.go
+++ b/pkg/controller/rolebinding.go
@@ -60,3 +60,7 @@ func (res rolebinding) Build() (runtime.Object, error) {
 func (res rolebinding) ShouldWatch() bool {
 	return false
 }
+
+func (res rolebinding) ShouldBeOwned() bool {
+	return false
+}

--- a/pkg/controller/rolebinding.go
+++ b/pkg/controller/rolebinding.go
@@ -1,59 +1,57 @@
-package component
+package controller
 
 import (
-	"fmt"
 	authorizv1 "github.com/openshift/api/authorization/v1"
 	"github.com/snowdrop/component-operator/pkg/apis/component/v1alpha2"
-	"github.com/snowdrop/component-operator/pkg/controller"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
 type rolebinding struct {
-	base
+	*DependentResourceHelper
 }
 
-func (res rolebinding) NewInstanceWith(owner v1alpha2.Resource) controller.DependentResource {
+func (res rolebinding) Update(toUpdate runtime.Object) (bool, error) {
+	return false, nil
+}
+
+func (res rolebinding) NewInstanceWith(owner v1alpha2.Resource) DependentResource {
 	return newOwnedRoleBinding(owner)
 }
 
-func newRoleBinding() rolebinding {
+func NewRoleBinding() rolebinding {
 	return newOwnedRoleBinding(nil)
 }
 
 func newOwnedRoleBinding(owner v1alpha2.Resource) rolebinding {
-	dependent := newBaseDependent(&authorizv1.RoleBinding{}, owner)
+	dependent := NewDependentResource(&authorizv1.RoleBinding{}, owner)
 	rolebinding := rolebinding{
-		base: dependent,
+		DependentResourceHelper: dependent,
 	}
 	dependent.SetDelegate(rolebinding)
 	return rolebinding
 }
 
 func (res rolebinding) Name() string {
-	return "edit"
+	return "use-scc-privileged"
 }
 
 func (res rolebinding) Build() (runtime.Object, error) {
-	c := res.ownerAsComponent()
+	c := res.Owner()
+	namespace := c.GetNamespace()
 	ser := &authorizv1.RoleBinding{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "rbac.authorization.k8s.io/v1beta1",
-			Kind:       "RoleBinding",
-		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      res.Name(),
-			Namespace: c.Namespace,
+			Namespace: namespace,
 		},
 		RoleRef: corev1.ObjectReference{
-			Name: "edit",
+			Kind:       "Role",
+			Name:       RoleName(c),
+			APIVersion: "rbac.authorization.k8s.io/v1beta1",
 		},
 		Subjects: []corev1.ObjectReference{
-			{Kind: "ServiceAccount", Name: ServiceAccountName(c), Namespace: c.Namespace},
-		},
-		UserNames: authorizv1.OptionalNames{
-			fmt.Sprintf("system:serviceaccount:%s:%s", c.Namespace, ServiceAccountName(c)),
+			{Kind: "ServiceAccount", Name: ServiceAccountName(c), Namespace: namespace},
 		},
 	}
 	return ser, nil

--- a/pkg/controller/scc.go
+++ b/pkg/controller/scc.go
@@ -50,7 +50,7 @@ func (res scc) Fetch(helper ReconcilerHelper) (runtime.Object, error) {
 }
 
 func (res scc) Build() (runtime.Object, error) {
-	panic("scc.Build should never be called: check your code!")
+	return nil, fmt.Errorf("scc.Build should never be called: check your code!")
 }
 
 func (res scc) Update(toUpdate runtime.Object) (bool, error) {

--- a/pkg/controller/scc.go
+++ b/pkg/controller/scc.go
@@ -12,6 +12,7 @@ type serviceAccountNamer func(owner v1alpha2.Resource) string
 type scc struct {
 	*DependentResourceHelper
 	serviceAccountNamer serviceAccountNamer
+	reconciler          *BaseGenericReconciler
 }
 
 func (res scc) NewInstanceWith(owner v1alpha2.Resource) DependentResource {
@@ -53,4 +54,8 @@ func (res scc) Update(toUpdate runtime.Object) (bool, error) {
 
 func (res scc) ShouldWatch() bool {
 	return false
+}
+
+func (res scc) CanBeCreatedOrUpdated() bool {
+	return res.reconciler.IsTargetClusterRunningOpenShift()
 }

--- a/pkg/controller/scc.go
+++ b/pkg/controller/scc.go
@@ -57,7 +57,7 @@ func (res scc) Update(toUpdate runtime.Object) (bool, error) {
 	toUpdateSCC := toUpdate.(*securityv1.SecurityContextConstraints)
 	owner := res.Owner()
 	sccUser := fmt.Sprintf("system:serviceaccount:%s:%s", owner.GetNamespace(), res.serviceAccountNamer(owner))
-	if util.Index(toUpdateSCC.Users, sccUser) >= 0 {
+	if util.Index(toUpdateSCC.Users, sccUser) < 0 {
 		toUpdateSCC.Users = append(toUpdateSCC.Users, sccUser)
 		return true, nil
 	}

--- a/pkg/controller/scc.go
+++ b/pkg/controller/scc.go
@@ -16,18 +16,19 @@ type scc struct {
 }
 
 func (res scc) NewInstanceWith(owner v1alpha2.Resource) DependentResource {
-	return newOwnedScc(owner, res.serviceAccountNamer)
+	return newOwnedScc(res.reconciler, owner, res.serviceAccountNamer)
 }
 
-func NewScc(serviceAccountNamer serviceAccountNamer) scc {
-	return newOwnedScc(nil, serviceAccountNamer)
+func NewScc(reconciler *BaseGenericReconciler, serviceAccountNamer serviceAccountNamer) scc {
+	return newOwnedScc(reconciler, nil, serviceAccountNamer)
 }
 
-func newOwnedScc(owner v1alpha2.Resource, serviceAccountNamer serviceAccountNamer) scc {
+func newOwnedScc(reconciler *BaseGenericReconciler, owner v1alpha2.Resource, serviceAccountNamer serviceAccountNamer) scc {
 	dependent := NewDependentResource(&securityv1.SecurityContextConstraints{}, owner)
 	scc := scc{
 		DependentResourceHelper: dependent,
 		serviceAccountNamer:     serviceAccountNamer,
+		reconciler:              reconciler,
 	}
 	dependent.SetDelegate(scc)
 	return scc

--- a/pkg/util/commons.go
+++ b/pkg/util/commons.go
@@ -2,9 +2,6 @@ package util
 
 import (
 	"fmt"
-	"github.com/snowdrop/component-operator/pkg/apis/component/v1alpha2"
-	"k8s.io/apimachinery/pkg/runtime"
-	"reflect"
 )
 
 func GetImageReference(imageName string, version ...string) string {
@@ -15,14 +12,6 @@ func GetImageReference(imageName string, version ...string) string {
 	return fmt.Sprintf("%s:%s", imageName, runtimeVersion)
 }
 
-func GetObjectName(object runtime.Object) string {
-	t := reflect.TypeOf(object)
-	if t.Kind() == reflect.Ptr {
-		t = t.Elem()
-	}
-	return t.Name()
-}
-
 func Index(vs []string, t string) int {
 	for i, v := range vs {
 		if v == t {
@@ -30,10 +19,6 @@ func Index(vs []string, t string) int {
 		}
 	}
 	return -1
-}
-
-func DefaultDependentResourceNameFor(owner v1alpha2.Resource) string {
-	return owner.GetName()
 }
 
 func NewTrue() *bool {

--- a/pkg/util/commons.go
+++ b/pkg/util/commons.go
@@ -21,3 +21,12 @@ func GetObjectName(object runtime.Object) string {
 	}
 	return t.Name()
 }
+
+func Index(vs []string, t string) int {
+	for i, v := range vs {
+		if v == t {
+			return i
+		}
+	}
+	return -1
+}

--- a/pkg/util/commons.go
+++ b/pkg/util/commons.go
@@ -35,3 +35,13 @@ func Index(vs []string, t string) int {
 func DefaultDependentResourceNameFor(owner v1alpha2.Resource) string {
 	return owner.GetName()
 }
+
+func NewTrue() *bool {
+	b := true
+	return &b
+}
+
+func NewFalse() *bool {
+	b := false
+	return &b
+}

--- a/pkg/util/commons.go
+++ b/pkg/util/commons.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"fmt"
+	"github.com/snowdrop/component-operator/pkg/apis/component/v1alpha2"
 	"k8s.io/apimachinery/pkg/runtime"
 	"reflect"
 )
@@ -29,4 +30,8 @@ func Index(vs []string, t string) int {
 		}
 	}
 	return -1
+}
+
+func DefaultDependentResourceNameFor(owner v1alpha2.Resource) string {
+	return owner.GetName()
 }


### PR DESCRIPTION
Should fix #80.
Also took the opportunity to rationalize how names are generated and used so that we don't use the same names by coincidence but rather make the intent explicit.